### PR TITLE
release: publish current versions of nibijs and protojs

### DIFF
--- a/packages/indexer-nibi/package.json
+++ b/packages/indexer-nibi/package.json
@@ -25,5 +25,5 @@
     "jest": "^28.1.3",
     "ts-jest": "^28.0.0-next.3"
   },
-  "gitHead": "26f98095718dadc94cc714e63d68c8a8dfa49dbe"
+  "gitHead": "c3fa9bd3e03e16ca4896d32d33e343a1a0de1d7a"
 }

--- a/packages/indexer-nibi/package.json
+++ b/packages/indexer-nibi/package.json
@@ -25,5 +25,5 @@
     "jest": "^28.1.3",
     "ts-jest": "^28.0.0-next.3"
   },
-  "gitHead": "c3fa9bd3e03e16ca4896d32d33e343a1a0de1d7a"
+  "gitHead": "5ae4c365d566a06251fd5db1ed76d410030d3df1"
 }

--- a/packages/indexer-nibi/package.json
+++ b/packages/indexer-nibi/package.json
@@ -25,5 +25,5 @@
     "jest": "^28.1.3",
     "ts-jest": "^28.0.0-next.3"
   },
-  "gitHead": "5ae4c365d566a06251fd5db1ed76d410030d3df1"
+  "gitHead": "189a24da66595240102f4fddcda98a62f3f017ad"
 }

--- a/packages/nibijs/docs/classes/CustomChain.md
+++ b/packages/nibijs/docs/classes/CustomChain.md
@@ -56,7 +56,7 @@ export const TEST_CHAIN = new CustomChain({
 
 #### Defined in
 
-[chain/chain.ts:67](https://github.com/NibiruChain/ts-sdk/blob/24502db/packages/nibijs/src/chain/chain.ts#L67)
+[chain/chain.ts:67](https://github.com/NibiruChain/ts-sdk/blob/c3fa9bd/packages/nibijs/src/chain/chain.ts#L67)
 
 ## Properties
 
@@ -72,7 +72,7 @@ chainId: identifier for the chain
 
 #### Defined in
 
-[chain/chain.ts:58](https://github.com/NibiruChain/ts-sdk/blob/24502db/packages/nibijs/src/chain/chain.ts#L58)
+[chain/chain.ts:58](https://github.com/NibiruChain/ts-sdk/blob/c3fa9bd/packages/nibijs/src/chain/chain.ts#L58)
 
 ___
 
@@ -82,7 +82,7 @@ ___
 
 #### Defined in
 
-[chain/chain.ts:65](https://github.com/NibiruChain/ts-sdk/blob/24502db/packages/nibijs/src/chain/chain.ts#L65)
+[chain/chain.ts:65](https://github.com/NibiruChain/ts-sdk/blob/c3fa9bd/packages/nibijs/src/chain/chain.ts#L65)
 
 ___
 
@@ -98,7 +98,7 @@ chainName: the name of the chain to display to the user
 
 #### Defined in
 
-[chain/chain.ts:59](https://github.com/NibiruChain/ts-sdk/blob/24502db/packages/nibijs/src/chain/chain.ts#L59)
+[chain/chain.ts:59](https://github.com/NibiruChain/ts-sdk/blob/c3fa9bd/packages/nibijs/src/chain/chain.ts#L59)
 
 ___
 
@@ -114,7 +114,7 @@ endptGrpc: endpoint for the gRPC gateway. Usually on port 9090.
 
 #### Defined in
 
-[chain/chain.ts:62](https://github.com/NibiruChain/ts-sdk/blob/24502db/packages/nibijs/src/chain/chain.ts#L62)
+[chain/chain.ts:62](https://github.com/NibiruChain/ts-sdk/blob/c3fa9bd/packages/nibijs/src/chain/chain.ts#L62)
 
 ___
 
@@ -130,7 +130,7 @@ endptRest: endpoint for the REST server. Also, the LCD endpoint.
 
 #### Defined in
 
-[chain/chain.ts:61](https://github.com/NibiruChain/ts-sdk/blob/24502db/packages/nibijs/src/chain/chain.ts#L61)
+[chain/chain.ts:61](https://github.com/NibiruChain/ts-sdk/blob/c3fa9bd/packages/nibijs/src/chain/chain.ts#L61)
 
 ___
 
@@ -146,7 +146,7 @@ endptTm: endpoint for the Tendermint RPC server. Usually on port 26657.
 
 #### Defined in
 
-[chain/chain.ts:60](https://github.com/NibiruChain/ts-sdk/blob/24502db/packages/nibijs/src/chain/chain.ts#L60)
+[chain/chain.ts:60](https://github.com/NibiruChain/ts-sdk/blob/c3fa9bd/packages/nibijs/src/chain/chain.ts#L60)
 
 ___
 
@@ -162,7 +162,7 @@ feeDenom: the denomination of the fee to be paid for transactions.
 
 #### Defined in
 
-[chain/chain.ts:63](https://github.com/NibiruChain/ts-sdk/blob/24502db/packages/nibijs/src/chain/chain.ts#L63)
+[chain/chain.ts:63](https://github.com/NibiruChain/ts-sdk/blob/c3fa9bd/packages/nibijs/src/chain/chain.ts#L63)
 
 ## Methods
 
@@ -176,7 +176,7 @@ feeDenom: the denomination of the fee to be paid for transactions.
 
 #### Defined in
 
-[chain/chain.ts:77](https://github.com/NibiruChain/ts-sdk/blob/24502db/packages/nibijs/src/chain/chain.ts#L77)
+[chain/chain.ts:77](https://github.com/NibiruChain/ts-sdk/blob/c3fa9bd/packages/nibijs/src/chain/chain.ts#L77)
 
 ___
 
@@ -190,7 +190,7 @@ ___
 
 #### Defined in
 
-[chain/chain.ts:92](https://github.com/NibiruChain/ts-sdk/blob/24502db/packages/nibijs/src/chain/chain.ts#L92)
+[chain/chain.ts:92](https://github.com/NibiruChain/ts-sdk/blob/c3fa9bd/packages/nibijs/src/chain/chain.ts#L92)
 
 ___
 
@@ -204,7 +204,7 @@ ___
 
 #### Defined in
 
-[chain/chain.ts:87](https://github.com/NibiruChain/ts-sdk/blob/24502db/packages/nibijs/src/chain/chain.ts#L87)
+[chain/chain.ts:87](https://github.com/NibiruChain/ts-sdk/blob/c3fa9bd/packages/nibijs/src/chain/chain.ts#L87)
 
 ___
 
@@ -218,4 +218,4 @@ ___
 
 #### Defined in
 
-[chain/chain.ts:82](https://github.com/NibiruChain/ts-sdk/blob/24502db/packages/nibijs/src/chain/chain.ts#L82)
+[chain/chain.ts:82](https://github.com/NibiruChain/ts-sdk/blob/c3fa9bd/packages/nibijs/src/chain/chain.ts#L82)

--- a/packages/nibijs/docs/classes/NibiruQueryClient.md
+++ b/packages/nibijs/docs/classes/NibiruQueryClient.md
@@ -45,7 +45,7 @@ StargateClient.constructor
 
 #### Defined in
 
-[query/query.ts:56](https://github.com/NibiruChain/ts-sdk/blob/24502db/packages/nibijs/src/query/query.ts#L56)
+[query/query.ts:56](https://github.com/NibiruChain/ts-sdk/blob/c3fa9bd/packages/nibijs/src/query/query.ts#L56)
 
 ## Properties
 
@@ -55,7 +55,7 @@ StargateClient.constructor
 
 #### Defined in
 
-[query/query.ts:44](https://github.com/NibiruChain/ts-sdk/blob/24502db/packages/nibijs/src/query/query.ts#L44)
+[query/query.ts:44](https://github.com/NibiruChain/ts-sdk/blob/c3fa9bd/packages/nibijs/src/query/query.ts#L44)
 
 ___
 
@@ -65,7 +65,7 @@ ___
 
 #### Defined in
 
-[query/query.ts:45](https://github.com/NibiruChain/ts-sdk/blob/24502db/packages/nibijs/src/query/query.ts#L45)
+[query/query.ts:45](https://github.com/NibiruChain/ts-sdk/blob/c3fa9bd/packages/nibijs/src/query/query.ts#L45)
 
 ## Methods
 
@@ -85,7 +85,7 @@ ___
 
 #### Defined in
 
-[query/query.ts:80](https://github.com/NibiruChain/ts-sdk/blob/24502db/packages/nibijs/src/query/query.ts#L80)
+[query/query.ts:80](https://github.com/NibiruChain/ts-sdk/blob/c3fa9bd/packages/nibijs/src/query/query.ts#L80)
 
 ___
 
@@ -99,7 +99,7 @@ ___
 
 #### Defined in
 
-[query/query.ts:88](https://github.com/NibiruChain/ts-sdk/blob/24502db/packages/nibijs/src/query/query.ts#L88)
+[query/query.ts:88](https://github.com/NibiruChain/ts-sdk/blob/c3fa9bd/packages/nibijs/src/query/query.ts#L88)
 
 ___
 
@@ -124,4 +124,4 @@ StargateClient.connect
 
 #### Defined in
 
-[query/query.ts:47](https://github.com/NibiruChain/ts-sdk/blob/24502db/packages/nibijs/src/query/query.ts#L47)
+[query/query.ts:47](https://github.com/NibiruChain/ts-sdk/blob/c3fa9bd/packages/nibijs/src/query/query.ts#L47)

--- a/packages/nibijs/docs/classes/NibiruSigningClient.md
+++ b/packages/nibijs/docs/classes/NibiruSigningClient.md
@@ -46,7 +46,7 @@ SigningStargateClient.constructor
 
 #### Defined in
 
-[tx/signingClient.ts:64](https://github.com/NibiruChain/ts-sdk/blob/24502db/packages/nibijs/src/tx/signingClient.ts#L64)
+[tx/signingClient.ts:64](https://github.com/NibiruChain/ts-sdk/blob/c3fa9bd/packages/nibijs/src/tx/signingClient.ts#L64)
 
 ## Properties
 
@@ -56,7 +56,7 @@ SigningStargateClient.constructor
 
 #### Defined in
 
-[tx/signingClient.ts:37](https://github.com/NibiruChain/ts-sdk/blob/24502db/packages/nibijs/src/tx/signingClient.ts#L37)
+[tx/signingClient.ts:37](https://github.com/NibiruChain/ts-sdk/blob/c3fa9bd/packages/nibijs/src/tx/signingClient.ts#L37)
 
 ___
 
@@ -66,7 +66,7 @@ ___
 
 #### Defined in
 
-[tx/signingClient.ts:38](https://github.com/NibiruChain/ts-sdk/blob/24502db/packages/nibijs/src/tx/signingClient.ts#L38)
+[tx/signingClient.ts:38](https://github.com/NibiruChain/ts-sdk/blob/c3fa9bd/packages/nibijs/src/tx/signingClient.ts#L38)
 
 ## Methods
 
@@ -86,7 +86,7 @@ ___
 
 #### Defined in
 
-[tx/signingClient.ts:89](https://github.com/NibiruChain/ts-sdk/blob/24502db/packages/nibijs/src/tx/signingClient.ts#L89)
+[tx/signingClient.ts:89](https://github.com/NibiruChain/ts-sdk/blob/c3fa9bd/packages/nibijs/src/tx/signingClient.ts#L89)
 
 ___
 
@@ -100,7 +100,7 @@ ___
 
 #### Defined in
 
-[tx/signingClient.ts:97](https://github.com/NibiruChain/ts-sdk/blob/24502db/packages/nibijs/src/tx/signingClient.ts#L97)
+[tx/signingClient.ts:97](https://github.com/NibiruChain/ts-sdk/blob/c3fa9bd/packages/nibijs/src/tx/signingClient.ts#L97)
 
 ___
 
@@ -127,4 +127,4 @@ SigningStargateClient.connectWithSigner
 
 #### Defined in
 
-[tx/signingClient.ts:40](https://github.com/NibiruChain/ts-sdk/blob/24502db/packages/nibijs/src/tx/signingClient.ts#L40)
+[tx/signingClient.ts:40](https://github.com/NibiruChain/ts-sdk/blob/c3fa9bd/packages/nibijs/src/tx/signingClient.ts#L40)

--- a/packages/nibijs/docs/enums/BECH32_PREFIX.md
+++ b/packages/nibijs/docs/enums/BECH32_PREFIX.md
@@ -23,7 +23,7 @@ ADDR defines the Bech32 prefix of an account address
 
 #### Defined in
 
-[tx/signer.ts:12](https://github.com/NibiruChain/ts-sdk/blob/24502db/packages/nibijs/src/tx/signer.ts#L12)
+[tx/signer.ts:12](https://github.com/NibiruChain/ts-sdk/blob/c3fa9bd/packages/nibijs/src/tx/signer.ts#L12)
 
 ___
 
@@ -35,7 +35,7 @@ ADDR_VAL defines the Bech32 prefix of an validator's operator address
 
 #### Defined in
 
-[tx/signer.ts:14](https://github.com/NibiruChain/ts-sdk/blob/24502db/packages/nibijs/src/tx/signer.ts#L14)
+[tx/signer.ts:14](https://github.com/NibiruChain/ts-sdk/blob/c3fa9bd/packages/nibijs/src/tx/signer.ts#L14)
 
 ___
 
@@ -47,7 +47,7 @@ ADDR_VALCONS defines the Bech32 prefix of a consensus node address
 
 #### Defined in
 
-[tx/signer.ts:16](https://github.com/NibiruChain/ts-sdk/blob/24502db/packages/nibijs/src/tx/signer.ts#L16)
+[tx/signer.ts:16](https://github.com/NibiruChain/ts-sdk/blob/c3fa9bd/packages/nibijs/src/tx/signer.ts#L16)
 
 ___
 
@@ -59,7 +59,7 @@ PUB defines the Bech32 prefix of an account's public key
 
 #### Defined in
 
-[tx/signer.ts:18](https://github.com/NibiruChain/ts-sdk/blob/24502db/packages/nibijs/src/tx/signer.ts#L18)
+[tx/signer.ts:18](https://github.com/NibiruChain/ts-sdk/blob/c3fa9bd/packages/nibijs/src/tx/signer.ts#L18)
 
 ___
 
@@ -71,7 +71,7 @@ PUB_VAL defines the Bech32 prefix of an validator's operator public key
 
 #### Defined in
 
-[tx/signer.ts:20](https://github.com/NibiruChain/ts-sdk/blob/24502db/packages/nibijs/src/tx/signer.ts#L20)
+[tx/signer.ts:20](https://github.com/NibiruChain/ts-sdk/blob/c3fa9bd/packages/nibijs/src/tx/signer.ts#L20)
 
 ___
 
@@ -83,4 +83,4 @@ PUB_VALCONS defines the Bech32 prefix of a consensus node public key
 
 #### Defined in
 
-[tx/signer.ts:22](https://github.com/NibiruChain/ts-sdk/blob/24502db/packages/nibijs/src/tx/signer.ts#L22)
+[tx/signer.ts:22](https://github.com/NibiruChain/ts-sdk/blob/c3fa9bd/packages/nibijs/src/tx/signer.ts#L22)

--- a/packages/nibijs/docs/enums/Signer.md
+++ b/packages/nibijs/docs/enums/Signer.md
@@ -17,7 +17,7 @@
 
 #### Defined in
 
-[tx/signer.ts:71](https://github.com/NibiruChain/ts-sdk/blob/24502db/packages/nibijs/src/tx/signer.ts#L71)
+[tx/signer.ts:71](https://github.com/NibiruChain/ts-sdk/blob/c3fa9bd/packages/nibijs/src/tx/signer.ts#L71)
 
 ___
 
@@ -27,4 +27,4 @@ ___
 
 #### Defined in
 
-[tx/signer.ts:70](https://github.com/NibiruChain/ts-sdk/blob/24502db/packages/nibijs/src/tx/signer.ts#L70)
+[tx/signer.ts:70](https://github.com/NibiruChain/ts-sdk/blob/c3fa9bd/packages/nibijs/src/tx/signer.ts#L70)

--- a/packages/nibijs/docs/interfaces/Attribute.md
+++ b/packages/nibijs/docs/interfaces/Attribute.md
@@ -17,7 +17,7 @@
 
 #### Defined in
 
-[chain/types.ts:53](https://github.com/NibiruChain/ts-sdk/blob/24502db/packages/nibijs/src/chain/types.ts#L53)
+[chain/types.ts:53](https://github.com/NibiruChain/ts-sdk/blob/c3fa9bd/packages/nibijs/src/chain/types.ts#L53)
 
 ___
 
@@ -27,4 +27,4 @@ ___
 
 #### Defined in
 
-[chain/types.ts:54](https://github.com/NibiruChain/ts-sdk/blob/24502db/packages/nibijs/src/chain/types.ts#L54)
+[chain/types.ts:54](https://github.com/NibiruChain/ts-sdk/blob/c3fa9bd/packages/nibijs/src/chain/types.ts#L54)

--- a/packages/nibijs/docs/interfaces/Chain.md
+++ b/packages/nibijs/docs/interfaces/Chain.md
@@ -40,7 +40,7 @@ chainId: identifier for the chain
 
 #### Defined in
 
-[chain/chain.ts:22](https://github.com/NibiruChain/ts-sdk/blob/24502db/packages/nibijs/src/chain/chain.ts#L22)
+[chain/chain.ts:22](https://github.com/NibiruChain/ts-sdk/blob/c3fa9bd/packages/nibijs/src/chain/chain.ts#L22)
 
 ___
 
@@ -52,7 +52,7 @@ chainName: the name of the chain to display to the user
 
 #### Defined in
 
-[chain/chain.ts:24](https://github.com/NibiruChain/ts-sdk/blob/24502db/packages/nibijs/src/chain/chain.ts#L24)
+[chain/chain.ts:24](https://github.com/NibiruChain/ts-sdk/blob/c3fa9bd/packages/nibijs/src/chain/chain.ts#L24)
 
 ___
 
@@ -64,7 +64,7 @@ endptGrpc: endpoint for the gRPC gateway. Usually on port 9090.
 
 #### Defined in
 
-[chain/chain.ts:20](https://github.com/NibiruChain/ts-sdk/blob/24502db/packages/nibijs/src/chain/chain.ts#L20)
+[chain/chain.ts:20](https://github.com/NibiruChain/ts-sdk/blob/c3fa9bd/packages/nibijs/src/chain/chain.ts#L20)
 
 ___
 
@@ -76,7 +76,7 @@ endptRest: endpoint for the REST server. Also, the LCD endpoint.
 
 #### Defined in
 
-[chain/chain.ts:18](https://github.com/NibiruChain/ts-sdk/blob/24502db/packages/nibijs/src/chain/chain.ts#L18)
+[chain/chain.ts:18](https://github.com/NibiruChain/ts-sdk/blob/c3fa9bd/packages/nibijs/src/chain/chain.ts#L18)
 
 ___
 
@@ -88,7 +88,7 @@ endptTm: endpoint for the Tendermint RPC server. Usually on port 26657.
 
 #### Defined in
 
-[chain/chain.ts:16](https://github.com/NibiruChain/ts-sdk/blob/24502db/packages/nibijs/src/chain/chain.ts#L16)
+[chain/chain.ts:16](https://github.com/NibiruChain/ts-sdk/blob/c3fa9bd/packages/nibijs/src/chain/chain.ts#L16)
 
 ___
 
@@ -100,4 +100,4 @@ feeDenom: the denomination of the fee to be paid for transactions.
 
 #### Defined in
 
-[chain/chain.ts:26](https://github.com/NibiruChain/ts-sdk/blob/24502db/packages/nibijs/src/chain/chain.ts#L26)
+[chain/chain.ts:26](https://github.com/NibiruChain/ts-sdk/blob/c3fa9bd/packages/nibijs/src/chain/chain.ts#L26)

--- a/packages/nibijs/docs/interfaces/ChainIdParts.md
+++ b/packages/nibijs/docs/interfaces/ChainIdParts.md
@@ -18,7 +18,7 @@
 
 #### Defined in
 
-[chain/chain.ts:42](https://github.com/NibiruChain/ts-sdk/blob/24502db/packages/nibijs/src/chain/chain.ts#L42)
+[chain/chain.ts:42](https://github.com/NibiruChain/ts-sdk/blob/c3fa9bd/packages/nibijs/src/chain/chain.ts#L42)
 
 ___
 
@@ -28,7 +28,7 @@ ___
 
 #### Defined in
 
-[chain/chain.ts:40](https://github.com/NibiruChain/ts-sdk/blob/24502db/packages/nibijs/src/chain/chain.ts#L40)
+[chain/chain.ts:40](https://github.com/NibiruChain/ts-sdk/blob/c3fa9bd/packages/nibijs/src/chain/chain.ts#L40)
 
 ___
 
@@ -38,4 +38,4 @@ ___
 
 #### Defined in
 
-[chain/chain.ts:41](https://github.com/NibiruChain/ts-sdk/blob/24502db/packages/nibijs/src/chain/chain.ts#L41)
+[chain/chain.ts:41](https://github.com/NibiruChain/ts-sdk/blob/c3fa9bd/packages/nibijs/src/chain/chain.ts#L41)

--- a/packages/nibijs/docs/interfaces/Event.md
+++ b/packages/nibijs/docs/interfaces/Event.md
@@ -17,7 +17,7 @@
 
 #### Defined in
 
-[chain/types.ts:49](https://github.com/NibiruChain/ts-sdk/blob/24502db/packages/nibijs/src/chain/types.ts#L49)
+[chain/types.ts:49](https://github.com/NibiruChain/ts-sdk/blob/c3fa9bd/packages/nibijs/src/chain/types.ts#L49)
 
 ___
 
@@ -27,4 +27,4 @@ ___
 
 #### Defined in
 
-[chain/types.ts:48](https://github.com/NibiruChain/ts-sdk/blob/24502db/packages/nibijs/src/chain/types.ts#L48)
+[chain/types.ts:48](https://github.com/NibiruChain/ts-sdk/blob/c3fa9bd/packages/nibijs/src/chain/types.ts#L48)

--- a/packages/nibijs/docs/interfaces/TxLog.md
+++ b/packages/nibijs/docs/interfaces/TxLog.md
@@ -16,4 +16,4 @@
 
 #### Defined in
 
-[chain/types.ts:58](https://github.com/NibiruChain/ts-sdk/blob/24502db/packages/nibijs/src/chain/types.ts#L58)
+[chain/types.ts:58](https://github.com/NibiruChain/ts-sdk/blob/c3fa9bd/packages/nibijs/src/chain/types.ts#L58)

--- a/packages/nibijs/docs/modules.md
+++ b/packages/nibijs/docs/modules.md
@@ -64,7 +64,7 @@
 
 #### Defined in
 
-[query/query.ts:29](https://github.com/NibiruChain/ts-sdk/blob/24502db/packages/nibijs/src/query/query.ts#L29)
+[query/query.ts:29](https://github.com/NibiruChain/ts-sdk/blob/c3fa9bd/packages/nibijs/src/query/query.ts#L29)
 
 ## Variables
 
@@ -74,7 +74,7 @@
 
 #### Defined in
 
-[chain/parse.ts:2](https://github.com/NibiruChain/ts-sdk/blob/24502db/packages/nibijs/src/chain/parse.ts#L2)
+[chain/parse.ts:2](https://github.com/NibiruChain/ts-sdk/blob/c3fa9bd/packages/nibijs/src/chain/parse.ts#L2)
 
 ___
 
@@ -84,7 +84,7 @@ ___
 
 #### Defined in
 
-[chain/chain.ts:98](https://github.com/NibiruChain/ts-sdk/blob/24502db/packages/nibijs/src/chain/chain.ts#L98)
+[chain/chain.ts:98](https://github.com/NibiruChain/ts-sdk/blob/c3fa9bd/packages/nibijs/src/chain/chain.ts#L98)
 
 ___
 
@@ -94,7 +94,7 @@ ___
 
 #### Defined in
 
-[tx/signingClient.ts:30](https://github.com/NibiruChain/ts-sdk/blob/24502db/packages/nibijs/src/tx/signingClient.ts#L30)
+[tx/signingClient.ts:30](https://github.com/NibiruChain/ts-sdk/blob/c3fa9bd/packages/nibijs/src/tx/signingClient.ts#L30)
 
 ## Functions
 
@@ -114,7 +114,7 @@ ___
 
 #### Defined in
 
-[chain/chain.ts:115](https://github.com/NibiruChain/ts-sdk/blob/24502db/packages/nibijs/src/chain/chain.ts#L115)
+[chain/chain.ts:115](https://github.com/NibiruChain/ts-sdk/blob/c3fa9bd/packages/nibijs/src/chain/chain.ts#L115)
 
 ___
 
@@ -134,7 +134,7 @@ ___
 
 #### Defined in
 
-[chain/chain.ts:107](https://github.com/NibiruChain/ts-sdk/blob/24502db/packages/nibijs/src/chain/chain.ts#L107)
+[chain/chain.ts:107](https://github.com/NibiruChain/ts-sdk/blob/c3fa9bd/packages/nibijs/src/chain/chain.ts#L107)
 
 ___
 
@@ -155,7 +155,7 @@ ___
 
 #### Defined in
 
-[chain/types.ts:27](https://github.com/NibiruChain/ts-sdk/blob/24502db/packages/nibijs/src/chain/types.ts#L27)
+[chain/types.ts:27](https://github.com/NibiruChain/ts-sdk/blob/c3fa9bd/packages/nibijs/src/chain/types.ts#L27)
 
 ___
 
@@ -175,7 +175,7 @@ ___
 
 #### Defined in
 
-[chain/parse.ts:97](https://github.com/NibiruChain/ts-sdk/blob/24502db/packages/nibijs/src/chain/parse.ts#L97)
+[chain/parse.ts:97](https://github.com/NibiruChain/ts-sdk/blob/c3fa9bd/packages/nibijs/src/chain/parse.ts#L97)
 
 ___
 
@@ -195,7 +195,7 @@ ___
 
 #### Defined in
 
-[chain/parse.ts:156](https://github.com/NibiruChain/ts-sdk/blob/24502db/packages/nibijs/src/chain/parse.ts#L156)
+[chain/parse.ts:156](https://github.com/NibiruChain/ts-sdk/blob/c3fa9bd/packages/nibijs/src/chain/parse.ts#L156)
 
 ___
 
@@ -215,7 +215,7 @@ ___
 
 #### Defined in
 
-[chain/parse.ts:150](https://github.com/NibiruChain/ts-sdk/blob/24502db/packages/nibijs/src/chain/parse.ts#L150)
+[chain/parse.ts:150](https://github.com/NibiruChain/ts-sdk/blob/c3fa9bd/packages/nibijs/src/chain/parse.ts#L150)
 
 ___
 
@@ -235,7 +235,7 @@ ___
 
 #### Defined in
 
-[wallet/keplr.ts:9](https://github.com/NibiruChain/ts-sdk/blob/24502db/packages/nibijs/src/wallet/keplr.ts#L9)
+[wallet/keplr.ts:9](https://github.com/NibiruChain/ts-sdk/blob/c3fa9bd/packages/nibijs/src/wallet/keplr.ts#L9)
 
 ___
 
@@ -249,7 +249,7 @@ ___
 
 #### Defined in
 
-[tx/signer.ts:28](https://github.com/NibiruChain/ts-sdk/blob/24502db/packages/nibijs/src/tx/signer.ts#L28)
+[tx/signer.ts:28](https://github.com/NibiruChain/ts-sdk/blob/c3fa9bd/packages/nibijs/src/tx/signer.ts#L28)
 
 ___
 
@@ -275,7 +275,7 @@ ___
 
 #### Defined in
 
-[chain/types.ts:13](https://github.com/NibiruChain/ts-sdk/blob/24502db/packages/nibijs/src/chain/types.ts#L13)
+[chain/types.ts:13](https://github.com/NibiruChain/ts-sdk/blob/c3fa9bd/packages/nibijs/src/chain/types.ts#L13)
 
 ___
 
@@ -298,7 +298,7 @@ obj is Chain
 
 #### Defined in
 
-[chain/chain.ts:33](https://github.com/NibiruChain/ts-sdk/blob/24502db/packages/nibijs/src/chain/chain.ts#L33)
+[chain/chain.ts:33](https://github.com/NibiruChain/ts-sdk/blob/c3fa9bd/packages/nibijs/src/chain/chain.ts#L33)
 
 ___
 
@@ -318,7 +318,7 @@ ___
 
 #### Defined in
 
-[chain/chain.ts:134](https://github.com/NibiruChain/ts-sdk/blob/24502db/packages/nibijs/src/chain/chain.ts#L134)
+[chain/chain.ts:134](https://github.com/NibiruChain/ts-sdk/blob/c3fa9bd/packages/nibijs/src/chain/chain.ts#L134)
 
 ___
 
@@ -338,7 +338,7 @@ ___
 
 #### Defined in
 
-[chain/types.ts:39](https://github.com/NibiruChain/ts-sdk/blob/24502db/packages/nibijs/src/chain/types.ts#L39)
+[chain/types.ts:39](https://github.com/NibiruChain/ts-sdk/blob/c3fa9bd/packages/nibijs/src/chain/types.ts#L39)
 
 ___
 
@@ -365,7 +365,7 @@ A wallet for protobuf based signing using SIGN_MODE_DIRECT.
 
 #### Defined in
 
-[tx/signer.ts:62](https://github.com/NibiruChain/ts-sdk/blob/24502db/packages/nibijs/src/tx/signer.ts#L62)
+[tx/signer.ts:62](https://github.com/NibiruChain/ts-sdk/blob/c3fa9bd/packages/nibijs/src/tx/signer.ts#L62)
 
 ___
 
@@ -386,7 +386,7 @@ ___
 
 #### Defined in
 
-[tx/signer.ts:47](https://github.com/NibiruChain/ts-sdk/blob/24502db/packages/nibijs/src/tx/signer.ts#L47)
+[tx/signer.ts:47](https://github.com/NibiruChain/ts-sdk/blob/c3fa9bd/packages/nibijs/src/tx/signer.ts#L47)
 
 ___
 
@@ -413,7 +413,7 @@ A wallet for protobuf based signing using SIGN_MODE_DIRECT
 
 #### Defined in
 
-[tx/signer.ts:40](https://github.com/NibiruChain/ts-sdk/blob/24502db/packages/nibijs/src/tx/signer.ts#L40)
+[tx/signer.ts:40](https://github.com/NibiruChain/ts-sdk/blob/c3fa9bd/packages/nibijs/src/tx/signer.ts#L40)
 
 ___
 
@@ -433,7 +433,7 @@ ___
 
 #### Defined in
 
-[chain/chain.ts:123](https://github.com/NibiruChain/ts-sdk/blob/24502db/packages/nibijs/src/chain/chain.ts#L123)
+[chain/chain.ts:123](https://github.com/NibiruChain/ts-sdk/blob/c3fa9bd/packages/nibijs/src/chain/chain.ts#L123)
 
 ___
 
@@ -462,7 +462,7 @@ ref: Reimplementation of cosmos-sdk/types/decimal.go
 
 #### Defined in
 
-[chain/parse.ts:23](https://github.com/NibiruChain/ts-sdk/blob/24502db/packages/nibijs/src/chain/parse.ts#L23)
+[chain/parse.ts:23](https://github.com/NibiruChain/ts-sdk/blob/c3fa9bd/packages/nibijs/src/chain/parse.ts#L23)
 
 ___
 
@@ -482,7 +482,7 @@ ___
 
 #### Defined in
 
-[chain/parse.ts:146](https://github.com/NibiruChain/ts-sdk/blob/24502db/packages/nibijs/src/chain/parse.ts#L146)
+[chain/parse.ts:146](https://github.com/NibiruChain/ts-sdk/blob/c3fa9bd/packages/nibijs/src/chain/parse.ts#L146)
 
 ___
 
@@ -511,4 +511,4 @@ Sends 10 NIBI and 100 NUSD to the given address from the testnet faucet.
 
 #### Defined in
 
-[chain/useFaucet.ts:7](https://github.com/NibiruChain/ts-sdk/blob/24502db/packages/nibijs/src/chain/useFaucet.ts#L7)
+[chain/useFaucet.ts:7](https://github.com/NibiruChain/ts-sdk/blob/c3fa9bd/packages/nibijs/src/chain/useFaucet.ts#L7)

--- a/packages/nibijs/package.json
+++ b/packages/nibijs/package.json
@@ -39,5 +39,5 @@
     "typedoc": "^0.23.22",
     "typedoc-plugin-markdown": "^3.14.0"
   },
-  "gitHead": "5ae4c365d566a06251fd5db1ed76d410030d3df1"
+  "gitHead": "189a24da66595240102f4fddcda98a62f3f017ad"
 }

--- a/packages/nibijs/package.json
+++ b/packages/nibijs/package.json
@@ -22,7 +22,7 @@
     "@cosmjs/proto-signing": "^0.28.11",
     "@cosmjs/stargate": "^0.28.11",
     "@cosmjs/tendermint-rpc": "^0.28.11",
-    "@nibiruchain/protojs": "^0.19.2",
+    "@nibiruchain/protojs": "^0.19.3",
     "cross-fetch": "^3.1.5",
     "long": "^5.2.0"
   },
@@ -39,5 +39,5 @@
     "typedoc": "^0.23.22",
     "typedoc-plugin-markdown": "^3.14.0"
   },
-  "gitHead": "4da45aaaf65a44e6b4edc0b5d11ea1083229f977"
+  "gitHead": "c3fa9bd3e03e16ca4896d32d33e343a1a0de1d7a"
 }

--- a/packages/nibijs/package.json
+++ b/packages/nibijs/package.json
@@ -39,5 +39,5 @@
     "typedoc": "^0.23.22",
     "typedoc-plugin-markdown": "^3.14.0"
   },
-  "gitHead": "c3fa9bd3e03e16ca4896d32d33e343a1a0de1d7a"
+  "gitHead": "5ae4c365d566a06251fd5db1ed76d410030d3df1"
 }

--- a/packages/protojs/package.json
+++ b/packages/protojs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nibiruchain/protojs",
   "description": "Protobuf-generated types for Nibiru Chain",
-  "version": "0.19.2",
+  "version": "0.19.3",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -13,5 +13,5 @@
     "build:watch": "tsc --build --watch",
     "clean": "tsc --clean"
   },
-  "gitHead": "4da45aaaf65a44e6b4edc0b5d11ea1083229f977"
+  "gitHead": "c3fa9bd3e03e16ca4896d32d33e343a1a0de1d7a"
 }

--- a/packages/protojs/package.json
+++ b/packages/protojs/package.json
@@ -13,5 +13,5 @@
     "build:watch": "tsc --build --watch",
     "clean": "tsc --clean"
   },
-  "gitHead": "c3fa9bd3e03e16ca4896d32d33e343a1a0de1d7a"
+  "gitHead": "5ae4c365d566a06251fd5db1ed76d410030d3df1"
 }

--- a/packages/protojs/package.json
+++ b/packages/protojs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nibiruchain/protojs",
   "description": "Protobuf-generated types for Nibiru Chain",
-  "version": "0.19.3",
+  "version": "0.19.2",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -13,5 +13,5 @@
     "build:watch": "tsc --build --watch",
     "clean": "tsc --clean"
   },
-  "gitHead": "5ae4c365d566a06251fd5db1ed76d410030d3df1"
+  "gitHead": "189a24da66595240102f4fddcda98a62f3f017ad"
 }


### PR DESCRIPTION
- protojs v0.19.2 for protos from nibiru-itn-1
- nibijs v0.19.11
- indexer-nibi v0.6.0
