### PR TITLE
fix(polyfill): fetch

### DIFF
--- a/packages/indexer-nibi/CHANGELOG.md
+++ b/packages/indexer-nibi/CHANGELOG.md
@@ -7,6 +7,10 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 - .
 
+## v0.19.20
+
+- Update fetch polyfill
+
 ## v0.19.19
 
 - Update nibijs

--- a/packages/indexer-nibi/package.json
+++ b/packages/indexer-nibi/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nibiruchain/indexer-nibi",
   "description": "GraphQL API client for the Nibiru Chain indexer (heart-monitor)",
-  "version": "0.19.19",
+  "version": "0.19.20",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/indexer-nibi/src/gql.ts
+++ b/packages/indexer-nibi/src/gql.ts
@@ -1,4 +1,12 @@
-import fetch from "cross-fetch"
+import * as cf from "cross-fetch"
+
+declare global {
+  interface Window {
+    fetch: typeof cf.fetch
+  }
+}
+
+window.fetch = cf.fetch
 
 /**
  * The workhorse function that fetches data from the GraphQL endpoint.

--- a/packages/indexer-nibi/src/gql.ts
+++ b/packages/indexer-nibi/src/gql.ts
@@ -19,7 +19,7 @@ window.fetch = cf.fetch
 export async function doGqlQuery(gqlQuery: string, gqlEndpt: string): Promise<any> {
   const encodedGqlQuery = encodeURI(gqlQuery)
   const fetchString = `${gqlEndpt}?query=${encodedGqlQuery}`
-  const rawResp = await fetch(fetchString)
+  const rawResp = await window.fetch(fetchString)
   return cleanResponse(rawResp)
 }
 

--- a/packages/nibijs/CHANGELOG.md
+++ b/packages/nibijs/CHANGELOG.md
@@ -7,6 +7,10 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 - .
 
+## v0.19.20
+
+- Update fetch polyfill
+
 ## v0.19.19
 
 - Update Keplr version

--- a/packages/nibijs/docs/classes/CustomChain.md
+++ b/packages/nibijs/docs/classes/CustomChain.md
@@ -1,4 +1,4 @@
-[NibiJS Documentation - v0.19.19](../intro.md) / [Exports](../modules.md) / CustomChain
+[NibiJS Documentation - v0.19.20](../intro.md) / [Exports](../modules.md) / CustomChain
 
 # Class: CustomChain
 
@@ -56,7 +56,7 @@ export const TEST_CHAIN = new CustomChain({
 
 #### Defined in
 
-[chain/chain.ts:75](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/chain/chain.ts#L75)
+[chain/chain.ts:75](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/chain/chain.ts#L75)
 
 ## Properties
 
@@ -72,7 +72,7 @@ chainId: identifier for the chain
 
 #### Defined in
 
-[chain/chain.ts:66](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/chain/chain.ts#L66)
+[chain/chain.ts:66](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/chain/chain.ts#L66)
 
 ___
 
@@ -82,7 +82,7 @@ ___
 
 #### Defined in
 
-[chain/chain.ts:73](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/chain/chain.ts#L73)
+[chain/chain.ts:73](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/chain/chain.ts#L73)
 
 ___
 
@@ -98,7 +98,7 @@ chainName: the name of the chain to display to the user
 
 #### Defined in
 
-[chain/chain.ts:67](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/chain/chain.ts#L67)
+[chain/chain.ts:67](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/chain/chain.ts#L67)
 
 ___
 
@@ -114,7 +114,7 @@ endptGrpc: endpoint for the gRPC gateway. Usually on port 9090.
 
 #### Defined in
 
-[chain/chain.ts:70](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/chain/chain.ts#L70)
+[chain/chain.ts:70](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/chain/chain.ts#L70)
 
 ___
 
@@ -130,7 +130,7 @@ endptRest: endpoint for the REST server. Also, the LCD endpoint.
 
 #### Defined in
 
-[chain/chain.ts:69](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/chain/chain.ts#L69)
+[chain/chain.ts:69](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/chain/chain.ts#L69)
 
 ___
 
@@ -146,7 +146,7 @@ endptTm: endpoint for the Tendermint RPC server. Usually on port 26657.
 
 #### Defined in
 
-[chain/chain.ts:68](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/chain/chain.ts#L68)
+[chain/chain.ts:68](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/chain/chain.ts#L68)
 
 ___
 
@@ -162,7 +162,7 @@ feeDenom: the denomination of the fee to be paid for transactions.
 
 #### Defined in
 
-[chain/chain.ts:71](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/chain/chain.ts#L71)
+[chain/chain.ts:71](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/chain/chain.ts#L71)
 
 ## Methods
 
@@ -176,7 +176,7 @@ feeDenom: the denomination of the fee to be paid for transactions.
 
 #### Defined in
 
-[chain/chain.ts:85](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/chain/chain.ts#L85)
+[chain/chain.ts:85](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/chain/chain.ts#L85)
 
 ___
 
@@ -190,7 +190,7 @@ ___
 
 #### Defined in
 
-[chain/chain.ts:100](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/chain/chain.ts#L100)
+[chain/chain.ts:100](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/chain/chain.ts#L100)
 
 ___
 
@@ -204,7 +204,7 @@ ___
 
 #### Defined in
 
-[chain/chain.ts:95](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/chain/chain.ts#L95)
+[chain/chain.ts:95](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/chain/chain.ts#L95)
 
 ___
 
@@ -218,4 +218,4 @@ ___
 
 #### Defined in
 
-[chain/chain.ts:90](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/chain/chain.ts#L90)
+[chain/chain.ts:90](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/chain/chain.ts#L90)

--- a/packages/nibijs/docs/classes/CustomChain.md
+++ b/packages/nibijs/docs/classes/CustomChain.md
@@ -56,7 +56,7 @@ export const TEST_CHAIN = new CustomChain({
 
 #### Defined in
 
-[chain/chain.ts:67](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/chain/chain.ts#L67)
+[chain/chain.ts:75](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/chain/chain.ts#L75)
 
 ## Properties
 
@@ -72,7 +72,7 @@ chainId: identifier for the chain
 
 #### Defined in
 
-[chain/chain.ts:58](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/chain/chain.ts#L58)
+[chain/chain.ts:66](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/chain/chain.ts#L66)
 
 ___
 
@@ -82,7 +82,7 @@ ___
 
 #### Defined in
 
-[chain/chain.ts:65](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/chain/chain.ts#L65)
+[chain/chain.ts:73](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/chain/chain.ts#L73)
 
 ___
 
@@ -98,7 +98,7 @@ chainName: the name of the chain to display to the user
 
 #### Defined in
 
-[chain/chain.ts:59](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/chain/chain.ts#L59)
+[chain/chain.ts:67](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/chain/chain.ts#L67)
 
 ___
 
@@ -114,7 +114,7 @@ endptGrpc: endpoint for the gRPC gateway. Usually on port 9090.
 
 #### Defined in
 
-[chain/chain.ts:62](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/chain/chain.ts#L62)
+[chain/chain.ts:70](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/chain/chain.ts#L70)
 
 ___
 
@@ -130,7 +130,7 @@ endptRest: endpoint for the REST server. Also, the LCD endpoint.
 
 #### Defined in
 
-[chain/chain.ts:61](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/chain/chain.ts#L61)
+[chain/chain.ts:69](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/chain/chain.ts#L69)
 
 ___
 
@@ -146,7 +146,7 @@ endptTm: endpoint for the Tendermint RPC server. Usually on port 26657.
 
 #### Defined in
 
-[chain/chain.ts:60](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/chain/chain.ts#L60)
+[chain/chain.ts:68](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/chain/chain.ts#L68)
 
 ___
 
@@ -162,7 +162,7 @@ feeDenom: the denomination of the fee to be paid for transactions.
 
 #### Defined in
 
-[chain/chain.ts:63](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/chain/chain.ts#L63)
+[chain/chain.ts:71](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/chain/chain.ts#L71)
 
 ## Methods
 
@@ -176,7 +176,7 @@ feeDenom: the denomination of the fee to be paid for transactions.
 
 #### Defined in
 
-[chain/chain.ts:77](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/chain/chain.ts#L77)
+[chain/chain.ts:85](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/chain/chain.ts#L85)
 
 ___
 
@@ -190,7 +190,7 @@ ___
 
 #### Defined in
 
-[chain/chain.ts:92](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/chain/chain.ts#L92)
+[chain/chain.ts:100](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/chain/chain.ts#L100)
 
 ___
 
@@ -204,7 +204,7 @@ ___
 
 #### Defined in
 
-[chain/chain.ts:87](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/chain/chain.ts#L87)
+[chain/chain.ts:95](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/chain/chain.ts#L95)
 
 ___
 
@@ -218,4 +218,4 @@ ___
 
 #### Defined in
 
-[chain/chain.ts:82](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/chain/chain.ts#L82)
+[chain/chain.ts:90](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/chain/chain.ts#L90)

--- a/packages/nibijs/docs/classes/MsgFactory.md
+++ b/packages/nibijs/docs/classes/MsgFactory.md
@@ -1,4 +1,4 @@
-[NibiJS Documentation - v0.19.19](../intro.md) / [Exports](../modules.md) / MsgFactory
+[NibiJS Documentation - v0.19.20](../intro.md) / [Exports](../modules.md) / MsgFactory
 
 # Class: MsgFactory
 
@@ -27,7 +27,7 @@
 
 #### Defined in
 
-[msg/index.ts:7](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/msg/index.ts#L7)
+[msg/index.ts:7](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/msg/index.ts#L7)
 
 ___
 
@@ -37,4 +37,4 @@ ___
 
 #### Defined in
 
-[msg/index.ts:5](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/msg/index.ts#L5)
+[msg/index.ts:5](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/msg/index.ts#L5)

--- a/packages/nibijs/docs/classes/MsgFactory.md
+++ b/packages/nibijs/docs/classes/MsgFactory.md
@@ -27,7 +27,7 @@
 
 #### Defined in
 
-[msg/index.ts:7](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/msg/index.ts#L7)
+[msg/index.ts:7](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/msg/index.ts#L7)
 
 ___
 
@@ -37,4 +37,4 @@ ___
 
 #### Defined in
 
-[msg/index.ts:5](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/msg/index.ts#L5)
+[msg/index.ts:5](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/msg/index.ts#L5)

--- a/packages/nibijs/docs/classes/NibiruQueryClient.md
+++ b/packages/nibijs/docs/classes/NibiruQueryClient.md
@@ -45,7 +45,7 @@ StargateClient.constructor
 
 #### Defined in
 
-[query/query.ts:56](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/query/query.ts#L56)
+[query/query.ts:56](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/query/query.ts#L56)
 
 ## Properties
 
@@ -55,7 +55,7 @@ StargateClient.constructor
 
 #### Defined in
 
-[query/query.ts:44](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/query/query.ts#L44)
+[query/query.ts:44](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/query/query.ts#L44)
 
 ___
 
@@ -65,7 +65,7 @@ ___
 
 #### Defined in
 
-[query/query.ts:45](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/query/query.ts#L45)
+[query/query.ts:45](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/query/query.ts#L45)
 
 ## Methods
 
@@ -85,7 +85,7 @@ ___
 
 #### Defined in
 
-[query/query.ts:80](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/query/query.ts#L80)
+[query/query.ts:80](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/query/query.ts#L80)
 
 ___
 
@@ -99,7 +99,7 @@ ___
 
 #### Defined in
 
-[query/query.ts:88](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/query/query.ts#L88)
+[query/query.ts:88](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/query/query.ts#L88)
 
 ___
 
@@ -124,4 +124,4 @@ StargateClient.connect
 
 #### Defined in
 
-[query/query.ts:47](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/query/query.ts#L47)
+[query/query.ts:47](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/query/query.ts#L47)

--- a/packages/nibijs/docs/classes/NibiruQueryClient.md
+++ b/packages/nibijs/docs/classes/NibiruQueryClient.md
@@ -1,4 +1,4 @@
-[NibiJS Documentation - v0.19.19](../intro.md) / [Exports](../modules.md) / NibiruQueryClient
+[NibiJS Documentation - v0.19.20](../intro.md) / [Exports](../modules.md) / NibiruQueryClient
 
 # Class: NibiruQueryClient
 
@@ -45,7 +45,7 @@ StargateClient.constructor
 
 #### Defined in
 
-[query/query.ts:56](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/query/query.ts#L56)
+[query/query.ts:56](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/query/query.ts#L56)
 
 ## Properties
 
@@ -55,7 +55,7 @@ StargateClient.constructor
 
 #### Defined in
 
-[query/query.ts:44](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/query/query.ts#L44)
+[query/query.ts:44](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/query/query.ts#L44)
 
 ___
 
@@ -65,7 +65,7 @@ ___
 
 #### Defined in
 
-[query/query.ts:45](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/query/query.ts#L45)
+[query/query.ts:45](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/query/query.ts#L45)
 
 ## Methods
 
@@ -85,7 +85,7 @@ ___
 
 #### Defined in
 
-[query/query.ts:80](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/query/query.ts#L80)
+[query/query.ts:80](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/query/query.ts#L80)
 
 ___
 
@@ -99,7 +99,7 @@ ___
 
 #### Defined in
 
-[query/query.ts:88](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/query/query.ts#L88)
+[query/query.ts:88](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/query/query.ts#L88)
 
 ___
 
@@ -124,4 +124,4 @@ StargateClient.connect
 
 #### Defined in
 
-[query/query.ts:47](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/query/query.ts#L47)
+[query/query.ts:47](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/query/query.ts#L47)

--- a/packages/nibijs/docs/classes/NibiruSigningClient.md
+++ b/packages/nibijs/docs/classes/NibiruSigningClient.md
@@ -46,7 +46,7 @@ SigningStargateClient.constructor
 
 #### Defined in
 
-[tx/signingClient.ts:64](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/tx/signingClient.ts#L64)
+[tx/signingClient.ts:64](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/tx/signingClient.ts#L64)
 
 ## Properties
 
@@ -56,7 +56,7 @@ SigningStargateClient.constructor
 
 #### Defined in
 
-[tx/signingClient.ts:37](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/tx/signingClient.ts#L37)
+[tx/signingClient.ts:37](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/tx/signingClient.ts#L37)
 
 ___
 
@@ -66,7 +66,7 @@ ___
 
 #### Defined in
 
-[tx/signingClient.ts:38](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/tx/signingClient.ts#L38)
+[tx/signingClient.ts:38](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/tx/signingClient.ts#L38)
 
 ## Methods
 
@@ -86,7 +86,7 @@ ___
 
 #### Defined in
 
-[tx/signingClient.ts:89](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/tx/signingClient.ts#L89)
+[tx/signingClient.ts:89](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/tx/signingClient.ts#L89)
 
 ___
 
@@ -100,7 +100,7 @@ ___
 
 #### Defined in
 
-[tx/signingClient.ts:97](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/tx/signingClient.ts#L97)
+[tx/signingClient.ts:97](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/tx/signingClient.ts#L97)
 
 ___
 
@@ -127,4 +127,4 @@ SigningStargateClient.connectWithSigner
 
 #### Defined in
 
-[tx/signingClient.ts:40](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/tx/signingClient.ts#L40)
+[tx/signingClient.ts:40](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/tx/signingClient.ts#L40)

--- a/packages/nibijs/docs/classes/NibiruSigningClient.md
+++ b/packages/nibijs/docs/classes/NibiruSigningClient.md
@@ -1,4 +1,4 @@
-[NibiJS Documentation - v0.19.19](../intro.md) / [Exports](../modules.md) / NibiruSigningClient
+[NibiJS Documentation - v0.19.20](../intro.md) / [Exports](../modules.md) / NibiruSigningClient
 
 # Class: NibiruSigningClient
 
@@ -46,7 +46,7 @@ SigningStargateClient.constructor
 
 #### Defined in
 
-[tx/signingClient.ts:64](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/tx/signingClient.ts#L64)
+[tx/signingClient.ts:64](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/tx/signingClient.ts#L64)
 
 ## Properties
 
@@ -56,7 +56,7 @@ SigningStargateClient.constructor
 
 #### Defined in
 
-[tx/signingClient.ts:37](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/tx/signingClient.ts#L37)
+[tx/signingClient.ts:37](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/tx/signingClient.ts#L37)
 
 ___
 
@@ -66,7 +66,7 @@ ___
 
 #### Defined in
 
-[tx/signingClient.ts:38](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/tx/signingClient.ts#L38)
+[tx/signingClient.ts:38](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/tx/signingClient.ts#L38)
 
 ## Methods
 
@@ -86,7 +86,7 @@ ___
 
 #### Defined in
 
-[tx/signingClient.ts:89](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/tx/signingClient.ts#L89)
+[tx/signingClient.ts:89](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/tx/signingClient.ts#L89)
 
 ___
 
@@ -100,7 +100,7 @@ ___
 
 #### Defined in
 
-[tx/signingClient.ts:97](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/tx/signingClient.ts#L97)
+[tx/signingClient.ts:97](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/tx/signingClient.ts#L97)
 
 ___
 
@@ -127,4 +127,4 @@ SigningStargateClient.connectWithSigner
 
 #### Defined in
 
-[tx/signingClient.ts:40](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/tx/signingClient.ts#L40)
+[tx/signingClient.ts:40](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/tx/signingClient.ts#L40)

--- a/packages/nibijs/docs/classes/PerpMsgFactory.md
+++ b/packages/nibijs/docs/classes/PerpMsgFactory.md
@@ -47,7 +47,7 @@ Returns a 'TxMessage' for adding margin to a position
 
 #### Defined in
 
-[msg/perp.ts:134](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/msg/perp.ts#L134)
+[msg/perp.ts:134](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/msg/perp.ts#L134)
 
 ___
 
@@ -67,7 +67,7 @@ ___
 
 #### Defined in
 
-[msg/perp.ts:171](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/msg/perp.ts#L171)
+[msg/perp.ts:171](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/msg/perp.ts#L171)
 
 ___
 
@@ -87,7 +87,7 @@ ___
 
 #### Defined in
 
-[msg/perp.ts:178](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/msg/perp.ts#L178)
+[msg/perp.ts:178](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/msg/perp.ts#L178)
 
 ___
 
@@ -107,7 +107,7 @@ ___
 
 #### Defined in
 
-[msg/perp.ts:141](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/msg/perp.ts#L141)
+[msg/perp.ts:141](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/msg/perp.ts#L141)
 
 ___
 
@@ -133,7 +133,7 @@ ___
 
 #### Defined in
 
-[msg/perp.ts:148](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/msg/perp.ts#L148)
+[msg/perp.ts:148](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/msg/perp.ts#L148)
 
 ___
 
@@ -153,4 +153,4 @@ ___
 
 #### Defined in
 
-[msg/perp.ts:120](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/msg/perp.ts#L120)
+[msg/perp.ts:120](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/msg/perp.ts#L120)

--- a/packages/nibijs/docs/classes/PerpMsgFactory.md
+++ b/packages/nibijs/docs/classes/PerpMsgFactory.md
@@ -1,4 +1,4 @@
-[NibiJS Documentation - v0.19.19](../intro.md) / [Exports](../modules.md) / PerpMsgFactory
+[NibiJS Documentation - v0.19.20](../intro.md) / [Exports](../modules.md) / PerpMsgFactory
 
 # Class: PerpMsgFactory
 
@@ -47,7 +47,7 @@ Returns a 'TxMessage' for adding margin to a position
 
 #### Defined in
 
-[msg/perp.ts:134](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/msg/perp.ts#L134)
+[msg/perp.ts:134](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/msg/perp.ts#L134)
 
 ___
 
@@ -67,7 +67,7 @@ ___
 
 #### Defined in
 
-[msg/perp.ts:171](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/msg/perp.ts#L171)
+[msg/perp.ts:171](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/msg/perp.ts#L171)
 
 ___
 
@@ -87,7 +87,7 @@ ___
 
 #### Defined in
 
-[msg/perp.ts:178](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/msg/perp.ts#L178)
+[msg/perp.ts:178](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/msg/perp.ts#L178)
 
 ___
 
@@ -107,7 +107,7 @@ ___
 
 #### Defined in
 
-[msg/perp.ts:141](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/msg/perp.ts#L141)
+[msg/perp.ts:141](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/msg/perp.ts#L141)
 
 ___
 
@@ -133,7 +133,7 @@ ___
 
 #### Defined in
 
-[msg/perp.ts:148](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/msg/perp.ts#L148)
+[msg/perp.ts:148](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/msg/perp.ts#L148)
 
 ___
 
@@ -153,4 +153,4 @@ ___
 
 #### Defined in
 
-[msg/perp.ts:120](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/msg/perp.ts#L120)
+[msg/perp.ts:120](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/msg/perp.ts#L120)

--- a/packages/nibijs/docs/classes/SpotMsgFactory.md
+++ b/packages/nibijs/docs/classes/SpotMsgFactory.md
@@ -1,4 +1,4 @@
-[NibiJS Documentation - v0.19.19](../intro.md) / [Exports](../modules.md) / SpotMsgFactory
+[NibiJS Documentation - v0.19.20](../intro.md) / [Exports](../modules.md) / SpotMsgFactory
 
 # Class: SpotMsgFactory
 
@@ -39,7 +39,7 @@
 
 #### Defined in
 
-[msg/spot.ts:73](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/msg/spot.ts#L73)
+[msg/spot.ts:73](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/msg/spot.ts#L73)
 
 ___
 
@@ -59,7 +59,7 @@ ___
 
 #### Defined in
 
-[msg/spot.ts:98](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/msg/spot.ts#L98)
+[msg/spot.ts:98](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/msg/spot.ts#L98)
 
 ___
 
@@ -79,7 +79,7 @@ ___
 
 #### Defined in
 
-[msg/spot.ts:86](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/msg/spot.ts#L86)
+[msg/spot.ts:86](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/msg/spot.ts#L86)
 
 ___
 
@@ -99,4 +99,4 @@ ___
 
 #### Defined in
 
-[msg/spot.ts:109](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/msg/spot.ts#L109)
+[msg/spot.ts:109](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/msg/spot.ts#L109)

--- a/packages/nibijs/docs/classes/SpotMsgFactory.md
+++ b/packages/nibijs/docs/classes/SpotMsgFactory.md
@@ -39,19 +39,19 @@
 
 #### Defined in
 
-[msg/spot.ts:73](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/msg/spot.ts#L73)
+[msg/spot.ts:73](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/msg/spot.ts#L73)
 
 ___
 
 ### exitPool
 
-▸ `Static` **exitPool**(`msg`): [`TxMessage`](../interfaces/TxMessage.md)
+▸ `Static` **exitPool**(`«destructured»`): [`TxMessage`](../interfaces/TxMessage.md)
 
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
-| `msg` | `MsgExitPool` |
+| `«destructured»` | `MsgExitPool` |
 
 #### Returns
 
@@ -59,19 +59,19 @@ ___
 
 #### Defined in
 
-[msg/spot.ts:98](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/msg/spot.ts#L98)
+[msg/spot.ts:98](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/msg/spot.ts#L98)
 
 ___
 
 ### joinPool
 
-▸ `Static` **joinPool**(`msg`): [`TxMessage`](../interfaces/TxMessage.md)
+▸ `Static` **joinPool**(`«destructured»`): [`TxMessage`](../interfaces/TxMessage.md)
 
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
-| `msg` | `MsgJoinPool` |
+| `«destructured»` | `MsgJoinPool` |
 
 #### Returns
 
@@ -79,19 +79,19 @@ ___
 
 #### Defined in
 
-[msg/spot.ts:86](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/msg/spot.ts#L86)
+[msg/spot.ts:86](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/msg/spot.ts#L86)
 
 ___
 
 ### swapAssets
 
-▸ `Static` **swapAssets**(`msg`): [`TxMessage`](../interfaces/TxMessage.md)
+▸ `Static` **swapAssets**(`«destructured»`): [`TxMessage`](../interfaces/TxMessage.md)
 
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
-| `msg` | `MsgSwapAssets` |
+| `«destructured»` | `MsgSwapAssets` |
 
 #### Returns
 
@@ -99,4 +99,4 @@ ___
 
 #### Defined in
 
-[msg/spot.ts:109](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/msg/spot.ts#L109)
+[msg/spot.ts:109](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/msg/spot.ts#L109)

--- a/packages/nibijs/docs/enums/BECH32_PREFIX.md
+++ b/packages/nibijs/docs/enums/BECH32_PREFIX.md
@@ -23,7 +23,7 @@ ADDR defines the Bech32 prefix of an account address
 
 #### Defined in
 
-[tx/signer.ts:12](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/tx/signer.ts#L12)
+[tx/signer.ts:12](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/tx/signer.ts#L12)
 
 ___
 
@@ -35,7 +35,7 @@ ADDR_VAL defines the Bech32 prefix of an validator's operator address
 
 #### Defined in
 
-[tx/signer.ts:14](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/tx/signer.ts#L14)
+[tx/signer.ts:14](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/tx/signer.ts#L14)
 
 ___
 
@@ -47,7 +47,7 @@ ADDR_VALCONS defines the Bech32 prefix of a consensus node address
 
 #### Defined in
 
-[tx/signer.ts:16](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/tx/signer.ts#L16)
+[tx/signer.ts:16](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/tx/signer.ts#L16)
 
 ___
 
@@ -59,7 +59,7 @@ PUB defines the Bech32 prefix of an account's public key
 
 #### Defined in
 
-[tx/signer.ts:18](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/tx/signer.ts#L18)
+[tx/signer.ts:18](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/tx/signer.ts#L18)
 
 ___
 
@@ -71,7 +71,7 @@ PUB_VAL defines the Bech32 prefix of an validator's operator public key
 
 #### Defined in
 
-[tx/signer.ts:20](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/tx/signer.ts#L20)
+[tx/signer.ts:20](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/tx/signer.ts#L20)
 
 ___
 
@@ -83,4 +83,4 @@ PUB_VALCONS defines the Bech32 prefix of a consensus node public key
 
 #### Defined in
 
-[tx/signer.ts:22](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/tx/signer.ts#L22)
+[tx/signer.ts:22](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/tx/signer.ts#L22)

--- a/packages/nibijs/docs/enums/BECH32_PREFIX.md
+++ b/packages/nibijs/docs/enums/BECH32_PREFIX.md
@@ -1,4 +1,4 @@
-[NibiJS Documentation - v0.19.19](../intro.md) / [Exports](../modules.md) / BECH32\_PREFIX
+[NibiJS Documentation - v0.19.20](../intro.md) / [Exports](../modules.md) / BECH32\_PREFIX
 
 # Enumeration: BECH32\_PREFIX
 
@@ -23,7 +23,7 @@ ADDR defines the Bech32 prefix of an account address
 
 #### Defined in
 
-[tx/signer.ts:12](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/tx/signer.ts#L12)
+[tx/signer.ts:12](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/tx/signer.ts#L12)
 
 ___
 
@@ -35,7 +35,7 @@ ADDR_VAL defines the Bech32 prefix of an validator's operator address
 
 #### Defined in
 
-[tx/signer.ts:14](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/tx/signer.ts#L14)
+[tx/signer.ts:14](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/tx/signer.ts#L14)
 
 ___
 
@@ -47,7 +47,7 @@ ADDR_VALCONS defines the Bech32 prefix of a consensus node address
 
 #### Defined in
 
-[tx/signer.ts:16](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/tx/signer.ts#L16)
+[tx/signer.ts:16](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/tx/signer.ts#L16)
 
 ___
 
@@ -59,7 +59,7 @@ PUB defines the Bech32 prefix of an account's public key
 
 #### Defined in
 
-[tx/signer.ts:18](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/tx/signer.ts#L18)
+[tx/signer.ts:18](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/tx/signer.ts#L18)
 
 ___
 
@@ -71,7 +71,7 @@ PUB_VAL defines the Bech32 prefix of an validator's operator public key
 
 #### Defined in
 
-[tx/signer.ts:20](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/tx/signer.ts#L20)
+[tx/signer.ts:20](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/tx/signer.ts#L20)
 
 ___
 
@@ -83,4 +83,4 @@ PUB_VALCONS defines the Bech32 prefix of a consensus node public key
 
 #### Defined in
 
-[tx/signer.ts:22](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/tx/signer.ts#L22)
+[tx/signer.ts:22](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/tx/signer.ts#L22)

--- a/packages/nibijs/docs/enums/Signer.md
+++ b/packages/nibijs/docs/enums/Signer.md
@@ -17,7 +17,7 @@
 
 #### Defined in
 
-[tx/signer.ts:71](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/tx/signer.ts#L71)
+[tx/signer.ts:71](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/tx/signer.ts#L71)
 
 ___
 
@@ -27,4 +27,4 @@ ___
 
 #### Defined in
 
-[tx/signer.ts:70](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/tx/signer.ts#L70)
+[tx/signer.ts:70](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/tx/signer.ts#L70)

--- a/packages/nibijs/docs/enums/Signer.md
+++ b/packages/nibijs/docs/enums/Signer.md
@@ -1,4 +1,4 @@
-[NibiJS Documentation - v0.19.19](../intro.md) / [Exports](../modules.md) / Signer
+[NibiJS Documentation - v0.19.20](../intro.md) / [Exports](../modules.md) / Signer
 
 # Enumeration: Signer
 
@@ -17,7 +17,7 @@
 
 #### Defined in
 
-[tx/signer.ts:71](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/tx/signer.ts#L71)
+[tx/signer.ts:71](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/tx/signer.ts#L71)
 
 ___
 
@@ -27,4 +27,4 @@ ___
 
 #### Defined in
 
-[tx/signer.ts:70](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/tx/signer.ts#L70)
+[tx/signer.ts:70](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/tx/signer.ts#L70)

--- a/packages/nibijs/docs/interfaces/Attribute.md
+++ b/packages/nibijs/docs/interfaces/Attribute.md
@@ -17,7 +17,7 @@
 
 #### Defined in
 
-[chain/types.ts:53](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/chain/types.ts#L53)
+[chain/types.ts:53](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/chain/types.ts#L53)
 
 ___
 
@@ -27,4 +27,4 @@ ___
 
 #### Defined in
 
-[chain/types.ts:54](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/chain/types.ts#L54)
+[chain/types.ts:54](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/chain/types.ts#L54)

--- a/packages/nibijs/docs/interfaces/Attribute.md
+++ b/packages/nibijs/docs/interfaces/Attribute.md
@@ -1,4 +1,4 @@
-[NibiJS Documentation - v0.19.19](../intro.md) / [Exports](../modules.md) / Attribute
+[NibiJS Documentation - v0.19.20](../intro.md) / [Exports](../modules.md) / Attribute
 
 # Interface: Attribute
 
@@ -17,7 +17,7 @@
 
 #### Defined in
 
-[chain/types.ts:53](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/chain/types.ts#L53)
+[chain/types.ts:53](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/chain/types.ts#L53)
 
 ___
 
@@ -27,4 +27,4 @@ ___
 
 #### Defined in
 
-[chain/types.ts:54](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/chain/types.ts#L54)
+[chain/types.ts:54](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/chain/types.ts#L54)

--- a/packages/nibijs/docs/interfaces/Chain.md
+++ b/packages/nibijs/docs/interfaces/Chain.md
@@ -40,7 +40,7 @@ chainId: identifier for the chain
 
 #### Defined in
 
-[chain/chain.ts:22](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/chain/chain.ts#L22)
+[chain/chain.ts:30](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/chain/chain.ts#L30)
 
 ___
 
@@ -52,7 +52,7 @@ chainName: the name of the chain to display to the user
 
 #### Defined in
 
-[chain/chain.ts:24](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/chain/chain.ts#L24)
+[chain/chain.ts:32](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/chain/chain.ts#L32)
 
 ___
 
@@ -64,7 +64,7 @@ endptGrpc: endpoint for the gRPC gateway. Usually on port 9090.
 
 #### Defined in
 
-[chain/chain.ts:20](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/chain/chain.ts#L20)
+[chain/chain.ts:28](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/chain/chain.ts#L28)
 
 ___
 
@@ -76,7 +76,7 @@ endptRest: endpoint for the REST server. Also, the LCD endpoint.
 
 #### Defined in
 
-[chain/chain.ts:18](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/chain/chain.ts#L18)
+[chain/chain.ts:26](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/chain/chain.ts#L26)
 
 ___
 
@@ -88,7 +88,7 @@ endptTm: endpoint for the Tendermint RPC server. Usually on port 26657.
 
 #### Defined in
 
-[chain/chain.ts:16](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/chain/chain.ts#L16)
+[chain/chain.ts:24](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/chain/chain.ts#L24)
 
 ___
 
@@ -100,4 +100,4 @@ feeDenom: the denomination of the fee to be paid for transactions.
 
 #### Defined in
 
-[chain/chain.ts:26](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/chain/chain.ts#L26)
+[chain/chain.ts:34](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/chain/chain.ts#L34)

--- a/packages/nibijs/docs/interfaces/Chain.md
+++ b/packages/nibijs/docs/interfaces/Chain.md
@@ -1,4 +1,4 @@
-[NibiJS Documentation - v0.19.19](../intro.md) / [Exports](../modules.md) / Chain
+[NibiJS Documentation - v0.19.20](../intro.md) / [Exports](../modules.md) / Chain
 
 # Interface: Chain
 
@@ -40,7 +40,7 @@ chainId: identifier for the chain
 
 #### Defined in
 
-[chain/chain.ts:30](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/chain/chain.ts#L30)
+[chain/chain.ts:30](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/chain/chain.ts#L30)
 
 ___
 
@@ -52,7 +52,7 @@ chainName: the name of the chain to display to the user
 
 #### Defined in
 
-[chain/chain.ts:32](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/chain/chain.ts#L32)
+[chain/chain.ts:32](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/chain/chain.ts#L32)
 
 ___
 
@@ -64,7 +64,7 @@ endptGrpc: endpoint for the gRPC gateway. Usually on port 9090.
 
 #### Defined in
 
-[chain/chain.ts:28](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/chain/chain.ts#L28)
+[chain/chain.ts:28](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/chain/chain.ts#L28)
 
 ___
 
@@ -76,7 +76,7 @@ endptRest: endpoint for the REST server. Also, the LCD endpoint.
 
 #### Defined in
 
-[chain/chain.ts:26](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/chain/chain.ts#L26)
+[chain/chain.ts:26](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/chain/chain.ts#L26)
 
 ___
 
@@ -88,7 +88,7 @@ endptTm: endpoint for the Tendermint RPC server. Usually on port 26657.
 
 #### Defined in
 
-[chain/chain.ts:24](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/chain/chain.ts#L24)
+[chain/chain.ts:24](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/chain/chain.ts#L24)
 
 ___
 
@@ -100,4 +100,4 @@ feeDenom: the denomination of the fee to be paid for transactions.
 
 #### Defined in
 
-[chain/chain.ts:34](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/chain/chain.ts#L34)
+[chain/chain.ts:34](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/chain/chain.ts#L34)

--- a/packages/nibijs/docs/interfaces/ChainIdParts.md
+++ b/packages/nibijs/docs/interfaces/ChainIdParts.md
@@ -18,7 +18,7 @@
 
 #### Defined in
 
-[chain/chain.ts:42](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/chain/chain.ts#L42)
+[chain/chain.ts:50](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/chain/chain.ts#L50)
 
 ___
 
@@ -28,7 +28,7 @@ ___
 
 #### Defined in
 
-[chain/chain.ts:40](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/chain/chain.ts#L40)
+[chain/chain.ts:48](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/chain/chain.ts#L48)
 
 ___
 
@@ -38,4 +38,4 @@ ___
 
 #### Defined in
 
-[chain/chain.ts:41](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/chain/chain.ts#L41)
+[chain/chain.ts:49](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/chain/chain.ts#L49)

--- a/packages/nibijs/docs/interfaces/ChainIdParts.md
+++ b/packages/nibijs/docs/interfaces/ChainIdParts.md
@@ -1,4 +1,4 @@
-[NibiJS Documentation - v0.19.19](../intro.md) / [Exports](../modules.md) / ChainIdParts
+[NibiJS Documentation - v0.19.20](../intro.md) / [Exports](../modules.md) / ChainIdParts
 
 # Interface: ChainIdParts
 
@@ -18,7 +18,7 @@
 
 #### Defined in
 
-[chain/chain.ts:50](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/chain/chain.ts#L50)
+[chain/chain.ts:50](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/chain/chain.ts#L50)
 
 ___
 
@@ -28,7 +28,7 @@ ___
 
 #### Defined in
 
-[chain/chain.ts:48](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/chain/chain.ts#L48)
+[chain/chain.ts:48](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/chain/chain.ts#L48)
 
 ___
 
@@ -38,4 +38,4 @@ ___
 
 #### Defined in
 
-[chain/chain.ts:49](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/chain/chain.ts#L49)
+[chain/chain.ts:49](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/chain/chain.ts#L49)

--- a/packages/nibijs/docs/interfaces/CoinMap.md
+++ b/packages/nibijs/docs/interfaces/CoinMap.md
@@ -1,4 +1,4 @@
-[NibiJS Documentation - v0.19.19](../intro.md) / [Exports](../modules.md) / CoinMap
+[NibiJS Documentation - v0.19.20](../intro.md) / [Exports](../modules.md) / CoinMap
 
 # Interface: CoinMap
 

--- a/packages/nibijs/docs/interfaces/Event.md
+++ b/packages/nibijs/docs/interfaces/Event.md
@@ -17,7 +17,7 @@
 
 #### Defined in
 
-[chain/types.ts:49](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/chain/types.ts#L49)
+[chain/types.ts:49](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/chain/types.ts#L49)
 
 ___
 
@@ -27,4 +27,4 @@ ___
 
 #### Defined in
 
-[chain/types.ts:48](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/chain/types.ts#L48)
+[chain/types.ts:48](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/chain/types.ts#L48)

--- a/packages/nibijs/docs/interfaces/Event.md
+++ b/packages/nibijs/docs/interfaces/Event.md
@@ -1,4 +1,4 @@
-[NibiJS Documentation - v0.19.19](../intro.md) / [Exports](../modules.md) / Event
+[NibiJS Documentation - v0.19.20](../intro.md) / [Exports](../modules.md) / Event
 
 # Interface: Event
 
@@ -17,7 +17,7 @@
 
 #### Defined in
 
-[chain/types.ts:49](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/chain/types.ts#L49)
+[chain/types.ts:49](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/chain/types.ts#L49)
 
 ___
 
@@ -27,4 +27,4 @@ ___
 
 #### Defined in
 
-[chain/types.ts:48](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/chain/types.ts#L48)
+[chain/types.ts:48](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/chain/types.ts#L48)

--- a/packages/nibijs/docs/interfaces/MsgAddMarginEncodeObject.md
+++ b/packages/nibijs/docs/interfaces/MsgAddMarginEncodeObject.md
@@ -1,4 +1,4 @@
-[NibiJS Documentation - v0.19.19](../intro.md) / [Exports](../modules.md) / MsgAddMarginEncodeObject
+[NibiJS Documentation - v0.19.20](../intro.md) / [Exports](../modules.md) / MsgAddMarginEncodeObject
 
 # Interface: MsgAddMarginEncodeObject
 
@@ -27,7 +27,7 @@ EncodeObject.typeUrl
 
 #### Defined in
 
-[msg/perp.ts:34](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/msg/perp.ts#L34)
+[msg/perp.ts:34](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/msg/perp.ts#L34)
 
 ___
 
@@ -41,4 +41,4 @@ EncodeObject.value
 
 #### Defined in
 
-[msg/perp.ts:35](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/msg/perp.ts#L35)
+[msg/perp.ts:35](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/msg/perp.ts#L35)

--- a/packages/nibijs/docs/interfaces/MsgAddMarginEncodeObject.md
+++ b/packages/nibijs/docs/interfaces/MsgAddMarginEncodeObject.md
@@ -27,7 +27,7 @@ EncodeObject.typeUrl
 
 #### Defined in
 
-[msg/perp.ts:34](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/msg/perp.ts#L34)
+[msg/perp.ts:34](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/msg/perp.ts#L34)
 
 ___
 
@@ -41,4 +41,4 @@ EncodeObject.value
 
 #### Defined in
 
-[msg/perp.ts:35](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/msg/perp.ts#L35)
+[msg/perp.ts:35](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/msg/perp.ts#L35)

--- a/packages/nibijs/docs/interfaces/MsgClosePositionEncodeObject.md
+++ b/packages/nibijs/docs/interfaces/MsgClosePositionEncodeObject.md
@@ -27,7 +27,7 @@ EncodeObject.typeUrl
 
 #### Defined in
 
-[msg/perp.ts:90](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/msg/perp.ts#L90)
+[msg/perp.ts:90](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/msg/perp.ts#L90)
 
 ___
 
@@ -41,4 +41,4 @@ EncodeObject.value
 
 #### Defined in
 
-[msg/perp.ts:91](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/msg/perp.ts#L91)
+[msg/perp.ts:91](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/msg/perp.ts#L91)

--- a/packages/nibijs/docs/interfaces/MsgClosePositionEncodeObject.md
+++ b/packages/nibijs/docs/interfaces/MsgClosePositionEncodeObject.md
@@ -1,4 +1,4 @@
-[NibiJS Documentation - v0.19.19](../intro.md) / [Exports](../modules.md) / MsgClosePositionEncodeObject
+[NibiJS Documentation - v0.19.20](../intro.md) / [Exports](../modules.md) / MsgClosePositionEncodeObject
 
 # Interface: MsgClosePositionEncodeObject
 
@@ -27,7 +27,7 @@ EncodeObject.typeUrl
 
 #### Defined in
 
-[msg/perp.ts:90](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/msg/perp.ts#L90)
+[msg/perp.ts:90](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/msg/perp.ts#L90)
 
 ___
 
@@ -41,4 +41,4 @@ EncodeObject.value
 
 #### Defined in
 
-[msg/perp.ts:91](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/msg/perp.ts#L91)
+[msg/perp.ts:91](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/msg/perp.ts#L91)

--- a/packages/nibijs/docs/interfaces/MsgCreatePoolEncodeObject.md
+++ b/packages/nibijs/docs/interfaces/MsgCreatePoolEncodeObject.md
@@ -27,7 +27,7 @@ EncodeObject.typeUrl
 
 #### Defined in
 
-[msg/spot.ts:27](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/msg/spot.ts#L27)
+[msg/spot.ts:27](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/msg/spot.ts#L27)
 
 ___
 
@@ -41,4 +41,4 @@ EncodeObject.value
 
 #### Defined in
 
-[msg/spot.ts:28](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/msg/spot.ts#L28)
+[msg/spot.ts:28](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/msg/spot.ts#L28)

--- a/packages/nibijs/docs/interfaces/MsgCreatePoolEncodeObject.md
+++ b/packages/nibijs/docs/interfaces/MsgCreatePoolEncodeObject.md
@@ -1,4 +1,4 @@
-[NibiJS Documentation - v0.19.19](../intro.md) / [Exports](../modules.md) / MsgCreatePoolEncodeObject
+[NibiJS Documentation - v0.19.20](../intro.md) / [Exports](../modules.md) / MsgCreatePoolEncodeObject
 
 # Interface: MsgCreatePoolEncodeObject
 
@@ -27,7 +27,7 @@ EncodeObject.typeUrl
 
 #### Defined in
 
-[msg/spot.ts:27](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/msg/spot.ts#L27)
+[msg/spot.ts:27](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/msg/spot.ts#L27)
 
 ___
 
@@ -41,4 +41,4 @@ EncodeObject.value
 
 #### Defined in
 
-[msg/spot.ts:28](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/msg/spot.ts#L28)
+[msg/spot.ts:28](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/msg/spot.ts#L28)

--- a/packages/nibijs/docs/interfaces/MsgDonateToEcosystemFundEncodeObject.md
+++ b/packages/nibijs/docs/interfaces/MsgDonateToEcosystemFundEncodeObject.md
@@ -1,4 +1,4 @@
-[NibiJS Documentation - v0.19.19](../intro.md) / [Exports](../modules.md) / MsgDonateToEcosystemFundEncodeObject
+[NibiJS Documentation - v0.19.20](../intro.md) / [Exports](../modules.md) / MsgDonateToEcosystemFundEncodeObject
 
 # Interface: MsgDonateToEcosystemFundEncodeObject
 
@@ -27,7 +27,7 @@ EncodeObject.typeUrl
 
 #### Defined in
 
-[msg/perp.ts:104](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/msg/perp.ts#L104)
+[msg/perp.ts:104](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/msg/perp.ts#L104)
 
 ___
 
@@ -41,4 +41,4 @@ EncodeObject.value
 
 #### Defined in
 
-[msg/perp.ts:105](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/msg/perp.ts#L105)
+[msg/perp.ts:105](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/msg/perp.ts#L105)

--- a/packages/nibijs/docs/interfaces/MsgDonateToEcosystemFundEncodeObject.md
+++ b/packages/nibijs/docs/interfaces/MsgDonateToEcosystemFundEncodeObject.md
@@ -27,7 +27,7 @@ EncodeObject.typeUrl
 
 #### Defined in
 
-[msg/perp.ts:104](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/msg/perp.ts#L104)
+[msg/perp.ts:104](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/msg/perp.ts#L104)
 
 ___
 
@@ -41,4 +41,4 @@ EncodeObject.value
 
 #### Defined in
 
-[msg/perp.ts:105](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/msg/perp.ts#L105)
+[msg/perp.ts:105](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/msg/perp.ts#L105)

--- a/packages/nibijs/docs/interfaces/MsgExitPoolEncodeObject.md
+++ b/packages/nibijs/docs/interfaces/MsgExitPoolEncodeObject.md
@@ -1,4 +1,4 @@
-[NibiJS Documentation - v0.19.19](../intro.md) / [Exports](../modules.md) / MsgExitPoolEncodeObject
+[NibiJS Documentation - v0.19.20](../intro.md) / [Exports](../modules.md) / MsgExitPoolEncodeObject
 
 # Interface: MsgExitPoolEncodeObject
 
@@ -27,7 +27,7 @@ EncodeObject.typeUrl
 
 #### Defined in
 
-[msg/spot.ts:49](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/msg/spot.ts#L49)
+[msg/spot.ts:49](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/msg/spot.ts#L49)
 
 ___
 
@@ -41,4 +41,4 @@ EncodeObject.value
 
 #### Defined in
 
-[msg/spot.ts:50](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/msg/spot.ts#L50)
+[msg/spot.ts:50](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/msg/spot.ts#L50)

--- a/packages/nibijs/docs/interfaces/MsgExitPoolEncodeObject.md
+++ b/packages/nibijs/docs/interfaces/MsgExitPoolEncodeObject.md
@@ -27,7 +27,7 @@ EncodeObject.typeUrl
 
 #### Defined in
 
-[msg/spot.ts:49](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/msg/spot.ts#L49)
+[msg/spot.ts:49](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/msg/spot.ts#L49)
 
 ___
 
@@ -41,4 +41,4 @@ EncodeObject.value
 
 #### Defined in
 
-[msg/spot.ts:50](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/msg/spot.ts#L50)
+[msg/spot.ts:50](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/msg/spot.ts#L50)

--- a/packages/nibijs/docs/interfaces/MsgJoinPoolEncodeObject.md
+++ b/packages/nibijs/docs/interfaces/MsgJoinPoolEncodeObject.md
@@ -1,4 +1,4 @@
-[NibiJS Documentation - v0.19.19](../intro.md) / [Exports](../modules.md) / MsgJoinPoolEncodeObject
+[NibiJS Documentation - v0.19.20](../intro.md) / [Exports](../modules.md) / MsgJoinPoolEncodeObject
 
 # Interface: MsgJoinPoolEncodeObject
 
@@ -27,7 +27,7 @@ EncodeObject.typeUrl
 
 #### Defined in
 
-[msg/spot.ts:38](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/msg/spot.ts#L38)
+[msg/spot.ts:38](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/msg/spot.ts#L38)
 
 ___
 
@@ -41,4 +41,4 @@ EncodeObject.value
 
 #### Defined in
 
-[msg/spot.ts:39](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/msg/spot.ts#L39)
+[msg/spot.ts:39](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/msg/spot.ts#L39)

--- a/packages/nibijs/docs/interfaces/MsgJoinPoolEncodeObject.md
+++ b/packages/nibijs/docs/interfaces/MsgJoinPoolEncodeObject.md
@@ -27,7 +27,7 @@ EncodeObject.typeUrl
 
 #### Defined in
 
-[msg/spot.ts:38](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/msg/spot.ts#L38)
+[msg/spot.ts:38](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/msg/spot.ts#L38)
 
 ___
 
@@ -41,4 +41,4 @@ EncodeObject.value
 
 #### Defined in
 
-[msg/spot.ts:39](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/msg/spot.ts#L39)
+[msg/spot.ts:39](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/msg/spot.ts#L39)

--- a/packages/nibijs/docs/interfaces/MsgMultiLiquidateEncodeObject.md
+++ b/packages/nibijs/docs/interfaces/MsgMultiLiquidateEncodeObject.md
@@ -1,4 +1,4 @@
-[NibiJS Documentation - v0.19.19](../intro.md) / [Exports](../modules.md) / MsgMultiLiquidateEncodeObject
+[NibiJS Documentation - v0.19.20](../intro.md) / [Exports](../modules.md) / MsgMultiLiquidateEncodeObject
 
 # Interface: MsgMultiLiquidateEncodeObject
 
@@ -27,7 +27,7 @@ EncodeObject.typeUrl
 
 #### Defined in
 
-[msg/perp.ts:62](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/msg/perp.ts#L62)
+[msg/perp.ts:62](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/msg/perp.ts#L62)
 
 ___
 
@@ -41,4 +41,4 @@ EncodeObject.value
 
 #### Defined in
 
-[msg/perp.ts:63](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/msg/perp.ts#L63)
+[msg/perp.ts:63](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/msg/perp.ts#L63)

--- a/packages/nibijs/docs/interfaces/MsgMultiLiquidateEncodeObject.md
+++ b/packages/nibijs/docs/interfaces/MsgMultiLiquidateEncodeObject.md
@@ -27,7 +27,7 @@ EncodeObject.typeUrl
 
 #### Defined in
 
-[msg/perp.ts:62](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/msg/perp.ts#L62)
+[msg/perp.ts:62](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/msg/perp.ts#L62)
 
 ___
 
@@ -41,4 +41,4 @@ EncodeObject.value
 
 #### Defined in
 
-[msg/perp.ts:63](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/msg/perp.ts#L63)
+[msg/perp.ts:63](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/msg/perp.ts#L63)

--- a/packages/nibijs/docs/interfaces/MsgOpenPositionEncodeObject.md
+++ b/packages/nibijs/docs/interfaces/MsgOpenPositionEncodeObject.md
@@ -27,7 +27,7 @@ EncodeObject.typeUrl
 
 #### Defined in
 
-[msg/perp.ts:76](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/msg/perp.ts#L76)
+[msg/perp.ts:76](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/msg/perp.ts#L76)
 
 ___
 
@@ -41,4 +41,4 @@ EncodeObject.value
 
 #### Defined in
 
-[msg/perp.ts:77](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/msg/perp.ts#L77)
+[msg/perp.ts:77](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/msg/perp.ts#L77)

--- a/packages/nibijs/docs/interfaces/MsgOpenPositionEncodeObject.md
+++ b/packages/nibijs/docs/interfaces/MsgOpenPositionEncodeObject.md
@@ -1,4 +1,4 @@
-[NibiJS Documentation - v0.19.19](../intro.md) / [Exports](../modules.md) / MsgOpenPositionEncodeObject
+[NibiJS Documentation - v0.19.20](../intro.md) / [Exports](../modules.md) / MsgOpenPositionEncodeObject
 
 # Interface: MsgOpenPositionEncodeObject
 
@@ -27,7 +27,7 @@ EncodeObject.typeUrl
 
 #### Defined in
 
-[msg/perp.ts:76](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/msg/perp.ts#L76)
+[msg/perp.ts:76](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/msg/perp.ts#L76)
 
 ___
 
@@ -41,4 +41,4 @@ EncodeObject.value
 
 #### Defined in
 
-[msg/perp.ts:77](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/msg/perp.ts#L77)
+[msg/perp.ts:77](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/msg/perp.ts#L77)

--- a/packages/nibijs/docs/interfaces/MsgRemoveMarginEncodeObject.md
+++ b/packages/nibijs/docs/interfaces/MsgRemoveMarginEncodeObject.md
@@ -27,7 +27,7 @@ EncodeObject.typeUrl
 
 #### Defined in
 
-[msg/perp.ts:48](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/msg/perp.ts#L48)
+[msg/perp.ts:48](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/msg/perp.ts#L48)
 
 ___
 
@@ -41,4 +41,4 @@ EncodeObject.value
 
 #### Defined in
 
-[msg/perp.ts:49](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/msg/perp.ts#L49)
+[msg/perp.ts:49](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/msg/perp.ts#L49)

--- a/packages/nibijs/docs/interfaces/MsgRemoveMarginEncodeObject.md
+++ b/packages/nibijs/docs/interfaces/MsgRemoveMarginEncodeObject.md
@@ -1,4 +1,4 @@
-[NibiJS Documentation - v0.19.19](../intro.md) / [Exports](../modules.md) / MsgRemoveMarginEncodeObject
+[NibiJS Documentation - v0.19.20](../intro.md) / [Exports](../modules.md) / MsgRemoveMarginEncodeObject
 
 # Interface: MsgRemoveMarginEncodeObject
 
@@ -27,7 +27,7 @@ EncodeObject.typeUrl
 
 #### Defined in
 
-[msg/perp.ts:48](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/msg/perp.ts#L48)
+[msg/perp.ts:48](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/msg/perp.ts#L48)
 
 ___
 
@@ -41,4 +41,4 @@ EncodeObject.value
 
 #### Defined in
 
-[msg/perp.ts:49](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/msg/perp.ts#L49)
+[msg/perp.ts:49](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/msg/perp.ts#L49)

--- a/packages/nibijs/docs/interfaces/MsgSwapAssetsEncodeObject.md
+++ b/packages/nibijs/docs/interfaces/MsgSwapAssetsEncodeObject.md
@@ -1,4 +1,4 @@
-[NibiJS Documentation - v0.19.19](../intro.md) / [Exports](../modules.md) / MsgSwapAssetsEncodeObject
+[NibiJS Documentation - v0.19.20](../intro.md) / [Exports](../modules.md) / MsgSwapAssetsEncodeObject
 
 # Interface: MsgSwapAssetsEncodeObject
 
@@ -27,7 +27,7 @@ EncodeObject.typeUrl
 
 #### Defined in
 
-[msg/spot.ts:60](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/msg/spot.ts#L60)
+[msg/spot.ts:60](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/msg/spot.ts#L60)
 
 ___
 
@@ -41,4 +41,4 @@ EncodeObject.value
 
 #### Defined in
 
-[msg/spot.ts:61](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/msg/spot.ts#L61)
+[msg/spot.ts:61](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/msg/spot.ts#L61)

--- a/packages/nibijs/docs/interfaces/MsgSwapAssetsEncodeObject.md
+++ b/packages/nibijs/docs/interfaces/MsgSwapAssetsEncodeObject.md
@@ -27,7 +27,7 @@ EncodeObject.typeUrl
 
 #### Defined in
 
-[msg/spot.ts:60](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/msg/spot.ts#L60)
+[msg/spot.ts:60](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/msg/spot.ts#L60)
 
 ___
 
@@ -41,4 +41,4 @@ EncodeObject.value
 
 #### Defined in
 
-[msg/spot.ts:61](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/msg/spot.ts#L61)
+[msg/spot.ts:61](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/msg/spot.ts#L61)

--- a/packages/nibijs/docs/interfaces/MsgTypeUrls.md
+++ b/packages/nibijs/docs/interfaces/MsgTypeUrls.md
@@ -1,4 +1,4 @@
-[NibiJS Documentation - v0.19.19](../intro.md) / [Exports](../modules.md) / MsgTypeUrls
+[NibiJS Documentation - v0.19.20](../intro.md) / [Exports](../modules.md) / MsgTypeUrls
 
 # Interface: MsgTypeUrls
 

--- a/packages/nibijs/docs/interfaces/TxLog.md
+++ b/packages/nibijs/docs/interfaces/TxLog.md
@@ -1,4 +1,4 @@
-[NibiJS Documentation - v0.19.19](../intro.md) / [Exports](../modules.md) / TxLog
+[NibiJS Documentation - v0.19.20](../intro.md) / [Exports](../modules.md) / TxLog
 
 # Interface: TxLog
 
@@ -16,4 +16,4 @@
 
 #### Defined in
 
-[chain/types.ts:58](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/chain/types.ts#L58)
+[chain/types.ts:58](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/chain/types.ts#L58)

--- a/packages/nibijs/docs/interfaces/TxLog.md
+++ b/packages/nibijs/docs/interfaces/TxLog.md
@@ -16,4 +16,4 @@
 
 #### Defined in
 
-[chain/types.ts:58](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/chain/types.ts#L58)
+[chain/types.ts:58](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/chain/types.ts#L58)

--- a/packages/nibijs/docs/interfaces/TxMessage.md
+++ b/packages/nibijs/docs/interfaces/TxMessage.md
@@ -1,4 +1,4 @@
-[NibiJS Documentation - v0.19.19](../intro.md) / [Exports](../modules.md) / TxMessage
+[NibiJS Documentation - v0.19.20](../intro.md) / [Exports](../modules.md) / TxMessage
 
 # Interface: TxMessage
 

--- a/packages/nibijs/docs/intro.md
+++ b/packages/nibijs/docs/intro.md
@@ -1,4 +1,4 @@
-NibiJS Documentation - v0.19.19 / [Exports](modules.md)
+NibiJS Documentation - v0.19.20 / [Exports](modules.md)
 
 <p align="center">
 <img src="https://raw.githubusercontent.com/NibiruChain/ts-sdk/main/img/nibijs.png" width="100%">

--- a/packages/nibijs/docs/modules.md
+++ b/packages/nibijs/docs/modules.md
@@ -1,6 +1,6 @@
-[NibiJS Documentation - v0.19.19](intro.md) / Exports
+[NibiJS Documentation - v0.19.20](intro.md) / Exports
 
-# NibiJS Documentation - v0.19.19
+# NibiJS Documentation - v0.19.20
 
 ## Table of contents
 
@@ -94,7 +94,7 @@
 
 #### Defined in
 
-[query/query.ts:29](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/query/query.ts#L29)
+[query/query.ts:29](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/query/query.ts#L29)
 
 ## Variables
 
@@ -104,7 +104,7 @@
 
 #### Defined in
 
-[chain/parse.ts:2](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/chain/parse.ts#L2)
+[chain/parse.ts:2](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/chain/parse.ts#L2)
 
 ___
 
@@ -114,7 +114,7 @@ ___
 
 #### Defined in
 
-[chain/chain.ts:106](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/chain/chain.ts#L106)
+[chain/chain.ts:106](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/chain/chain.ts#L106)
 
 ___
 
@@ -124,7 +124,7 @@ ___
 
 #### Defined in
 
-[msg/index.ts:10](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/msg/index.ts#L10)
+[msg/index.ts:10](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/msg/index.ts#L10)
 
 ___
 
@@ -145,7 +145,7 @@ ___
 
 #### Defined in
 
-[msg/perp.ts:15](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/msg/perp.ts#L15)
+[msg/perp.ts:15](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/msg/perp.ts#L15)
 
 ___
 
@@ -164,7 +164,7 @@ ___
 
 #### Defined in
 
-[msg/spot.ts:12](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/msg/spot.ts#L12)
+[msg/spot.ts:12](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/msg/spot.ts#L12)
 
 ___
 
@@ -174,7 +174,7 @@ ___
 
 #### Defined in
 
-[tx/signingClient.ts:30](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/tx/signingClient.ts#L30)
+[tx/signingClient.ts:30](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/tx/signingClient.ts#L30)
 
 ___
 
@@ -184,7 +184,7 @@ ___
 
 #### Defined in
 
-[msg/perp.ts:24](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/msg/perp.ts#L24)
+[msg/perp.ts:24](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/msg/perp.ts#L24)
 
 ___
 
@@ -194,7 +194,7 @@ ___
 
 #### Defined in
 
-[msg/spot.ts:19](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/msg/spot.ts#L19)
+[msg/spot.ts:19](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/msg/spot.ts#L19)
 
 ## Functions
 
@@ -214,7 +214,7 @@ ___
 
 #### Defined in
 
-[chain/chain.ts:123](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/chain/chain.ts#L123)
+[chain/chain.ts:123](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/chain/chain.ts#L123)
 
 ___
 
@@ -234,7 +234,7 @@ ___
 
 #### Defined in
 
-[chain/chain.ts:115](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/chain/chain.ts#L115)
+[chain/chain.ts:115](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/chain/chain.ts#L115)
 
 ___
 
@@ -255,7 +255,7 @@ ___
 
 #### Defined in
 
-[chain/types.ts:27](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/chain/types.ts#L27)
+[chain/types.ts:27](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/chain/types.ts#L27)
 
 ___
 
@@ -275,7 +275,7 @@ ___
 
 #### Defined in
 
-[chain/parse.ts:97](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/chain/parse.ts#L97)
+[chain/parse.ts:97](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/chain/parse.ts#L97)
 
 ___
 
@@ -295,7 +295,7 @@ ___
 
 #### Defined in
 
-[chain/parse.ts:156](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/chain/parse.ts#L156)
+[chain/parse.ts:156](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/chain/parse.ts#L156)
 
 ___
 
@@ -315,7 +315,7 @@ ___
 
 #### Defined in
 
-[chain/parse.ts:150](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/chain/parse.ts#L150)
+[chain/parse.ts:150](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/chain/parse.ts#L150)
 
 ___
 
@@ -335,7 +335,7 @@ ___
 
 #### Defined in
 
-[wallet/keplr.ts:9](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/wallet/keplr.ts#L9)
+[wallet/keplr.ts:9](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/wallet/keplr.ts#L9)
 
 ___
 
@@ -349,7 +349,7 @@ ___
 
 #### Defined in
 
-[tx/signer.ts:28](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/tx/signer.ts#L28)
+[tx/signer.ts:28](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/tx/signer.ts#L28)
 
 ___
 
@@ -375,7 +375,7 @@ ___
 
 #### Defined in
 
-[chain/types.ts:13](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/chain/types.ts#L13)
+[chain/types.ts:13](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/chain/types.ts#L13)
 
 ___
 
@@ -398,7 +398,7 @@ obj is Chain
 
 #### Defined in
 
-[chain/chain.ts:41](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/chain/chain.ts#L41)
+[chain/chain.ts:41](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/chain/chain.ts#L41)
 
 ___
 
@@ -418,7 +418,7 @@ encodeObject is MsgAddMarginEncodeObject
 
 #### Defined in
 
-[msg/perp.ts:38](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/msg/perp.ts#L38)
+[msg/perp.ts:38](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/msg/perp.ts#L38)
 
 ___
 
@@ -438,7 +438,7 @@ encodeObject is MsgClosePositionEncodeObject
 
 #### Defined in
 
-[msg/perp.ts:94](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/msg/perp.ts#L94)
+[msg/perp.ts:94](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/msg/perp.ts#L94)
 
 ___
 
@@ -458,7 +458,7 @@ encodeObject is MsgCreatePoolEncodeObject
 
 #### Defined in
 
-[msg/spot.ts:31](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/msg/spot.ts#L31)
+[msg/spot.ts:31](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/msg/spot.ts#L31)
 
 ___
 
@@ -478,7 +478,7 @@ encodeObject is MsgDonateToEcosystemFundEncodeObject
 
 #### Defined in
 
-[msg/perp.ts:108](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/msg/perp.ts#L108)
+[msg/perp.ts:108](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/msg/perp.ts#L108)
 
 ___
 
@@ -498,7 +498,7 @@ encodeObject is MsgExitPoolEncodeObject
 
 #### Defined in
 
-[msg/spot.ts:53](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/msg/spot.ts#L53)
+[msg/spot.ts:53](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/msg/spot.ts#L53)
 
 ___
 
@@ -518,7 +518,7 @@ encodeObject is MsgJoinPoolEncodeObject
 
 #### Defined in
 
-[msg/spot.ts:42](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/msg/spot.ts#L42)
+[msg/spot.ts:42](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/msg/spot.ts#L42)
 
 ___
 
@@ -538,7 +538,7 @@ encodeObject is MsgMultiLiquidateEncodeObject
 
 #### Defined in
 
-[msg/perp.ts:66](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/msg/perp.ts#L66)
+[msg/perp.ts:66](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/msg/perp.ts#L66)
 
 ___
 
@@ -558,7 +558,7 @@ encodeObject is MsgOpenPositionEncodeObject
 
 #### Defined in
 
-[msg/perp.ts:80](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/msg/perp.ts#L80)
+[msg/perp.ts:80](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/msg/perp.ts#L80)
 
 ___
 
@@ -578,7 +578,7 @@ encodeObject is MsgRemoveMarginEncodeObject
 
 #### Defined in
 
-[msg/perp.ts:52](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/msg/perp.ts#L52)
+[msg/perp.ts:52](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/msg/perp.ts#L52)
 
 ___
 
@@ -598,7 +598,7 @@ encodeObject is MsgSwapAssetsEncodeObject
 
 #### Defined in
 
-[msg/spot.ts:64](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/msg/spot.ts#L64)
+[msg/spot.ts:64](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/msg/spot.ts#L64)
 
 ___
 
@@ -618,7 +618,7 @@ ___
 
 #### Defined in
 
-[chain/chain.ts:142](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/chain/chain.ts#L142)
+[chain/chain.ts:142](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/chain/chain.ts#L142)
 
 ___
 
@@ -638,7 +638,7 @@ ___
 
 #### Defined in
 
-[chain/types.ts:39](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/chain/types.ts#L39)
+[chain/types.ts:39](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/chain/types.ts#L39)
 
 ___
 
@@ -665,7 +665,7 @@ A wallet for protobuf based signing using SIGN_MODE_DIRECT.
 
 #### Defined in
 
-[tx/signer.ts:62](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/tx/signer.ts#L62)
+[tx/signer.ts:62](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/tx/signer.ts#L62)
 
 ___
 
@@ -686,7 +686,7 @@ ___
 
 #### Defined in
 
-[tx/signer.ts:47](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/tx/signer.ts#L47)
+[tx/signer.ts:47](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/tx/signer.ts#L47)
 
 ___
 
@@ -713,7 +713,7 @@ A wallet for protobuf based signing using SIGN_MODE_DIRECT
 
 #### Defined in
 
-[tx/signer.ts:40](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/tx/signer.ts#L40)
+[tx/signer.ts:40](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/tx/signer.ts#L40)
 
 ___
 
@@ -733,7 +733,7 @@ ___
 
 #### Defined in
 
-[chain/chain.ts:131](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/chain/chain.ts#L131)
+[chain/chain.ts:131](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/chain/chain.ts#L131)
 
 ___
 
@@ -762,7 +762,7 @@ ref: Reimplementation of cosmos-sdk/types/decimal.go
 
 #### Defined in
 
-[chain/parse.ts:23](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/chain/parse.ts#L23)
+[chain/parse.ts:23](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/chain/parse.ts#L23)
 
 ___
 
@@ -782,7 +782,7 @@ ___
 
 #### Defined in
 
-[chain/parse.ts:146](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/chain/parse.ts#L146)
+[chain/parse.ts:146](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/chain/parse.ts#L146)
 
 ___
 
@@ -811,4 +811,4 @@ Sends 10 NIBI and 100 NUSD to the given address from the testnet faucet.
 
 #### Defined in
 
-[chain/useFaucet.ts:15](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/chain/useFaucet.ts#L15)
+[chain/useFaucet.ts:15](https://github.com/NibiruChain/ts-sdk/blob/6819e4e/packages/nibijs/src/chain/useFaucet.ts#L15)

--- a/packages/nibijs/docs/modules.md
+++ b/packages/nibijs/docs/modules.md
@@ -94,7 +94,7 @@
 
 #### Defined in
 
-[query/query.ts:29](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/query/query.ts#L29)
+[query/query.ts:29](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/query/query.ts#L29)
 
 ## Variables
 
@@ -104,7 +104,7 @@
 
 #### Defined in
 
-[chain/parse.ts:2](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/chain/parse.ts#L2)
+[chain/parse.ts:2](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/chain/parse.ts#L2)
 
 ___
 
@@ -114,7 +114,7 @@ ___
 
 #### Defined in
 
-[chain/chain.ts:98](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/chain/chain.ts#L98)
+[chain/chain.ts:106](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/chain/chain.ts#L106)
 
 ___
 
@@ -124,7 +124,7 @@ ___
 
 #### Defined in
 
-[msg/index.ts:10](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/msg/index.ts#L10)
+[msg/index.ts:10](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/msg/index.ts#L10)
 
 ___
 
@@ -145,7 +145,7 @@ ___
 
 #### Defined in
 
-[msg/perp.ts:15](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/msg/perp.ts#L15)
+[msg/perp.ts:15](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/msg/perp.ts#L15)
 
 ___
 
@@ -164,7 +164,7 @@ ___
 
 #### Defined in
 
-[msg/spot.ts:12](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/msg/spot.ts#L12)
+[msg/spot.ts:12](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/msg/spot.ts#L12)
 
 ___
 
@@ -174,7 +174,7 @@ ___
 
 #### Defined in
 
-[tx/signingClient.ts:30](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/tx/signingClient.ts#L30)
+[tx/signingClient.ts:30](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/tx/signingClient.ts#L30)
 
 ___
 
@@ -184,7 +184,7 @@ ___
 
 #### Defined in
 
-[msg/perp.ts:24](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/msg/perp.ts#L24)
+[msg/perp.ts:24](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/msg/perp.ts#L24)
 
 ___
 
@@ -194,7 +194,7 @@ ___
 
 #### Defined in
 
-[msg/spot.ts:19](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/msg/spot.ts#L19)
+[msg/spot.ts:19](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/msg/spot.ts#L19)
 
 ## Functions
 
@@ -214,7 +214,7 @@ ___
 
 #### Defined in
 
-[chain/chain.ts:115](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/chain/chain.ts#L115)
+[chain/chain.ts:123](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/chain/chain.ts#L123)
 
 ___
 
@@ -234,7 +234,7 @@ ___
 
 #### Defined in
 
-[chain/chain.ts:107](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/chain/chain.ts#L107)
+[chain/chain.ts:115](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/chain/chain.ts#L115)
 
 ___
 
@@ -255,7 +255,7 @@ ___
 
 #### Defined in
 
-[chain/types.ts:27](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/chain/types.ts#L27)
+[chain/types.ts:27](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/chain/types.ts#L27)
 
 ___
 
@@ -275,7 +275,7 @@ ___
 
 #### Defined in
 
-[chain/parse.ts:97](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/chain/parse.ts#L97)
+[chain/parse.ts:97](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/chain/parse.ts#L97)
 
 ___
 
@@ -295,7 +295,7 @@ ___
 
 #### Defined in
 
-[chain/parse.ts:156](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/chain/parse.ts#L156)
+[chain/parse.ts:156](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/chain/parse.ts#L156)
 
 ___
 
@@ -315,7 +315,7 @@ ___
 
 #### Defined in
 
-[chain/parse.ts:150](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/chain/parse.ts#L150)
+[chain/parse.ts:150](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/chain/parse.ts#L150)
 
 ___
 
@@ -335,7 +335,7 @@ ___
 
 #### Defined in
 
-[wallet/keplr.ts:9](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/wallet/keplr.ts#L9)
+[wallet/keplr.ts:9](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/wallet/keplr.ts#L9)
 
 ___
 
@@ -349,7 +349,7 @@ ___
 
 #### Defined in
 
-[tx/signer.ts:28](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/tx/signer.ts#L28)
+[tx/signer.ts:28](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/tx/signer.ts#L28)
 
 ___
 
@@ -375,7 +375,7 @@ ___
 
 #### Defined in
 
-[chain/types.ts:13](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/chain/types.ts#L13)
+[chain/types.ts:13](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/chain/types.ts#L13)
 
 ___
 
@@ -398,7 +398,7 @@ obj is Chain
 
 #### Defined in
 
-[chain/chain.ts:33](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/chain/chain.ts#L33)
+[chain/chain.ts:41](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/chain/chain.ts#L41)
 
 ___
 
@@ -418,7 +418,7 @@ encodeObject is MsgAddMarginEncodeObject
 
 #### Defined in
 
-[msg/perp.ts:38](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/msg/perp.ts#L38)
+[msg/perp.ts:38](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/msg/perp.ts#L38)
 
 ___
 
@@ -438,7 +438,7 @@ encodeObject is MsgClosePositionEncodeObject
 
 #### Defined in
 
-[msg/perp.ts:94](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/msg/perp.ts#L94)
+[msg/perp.ts:94](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/msg/perp.ts#L94)
 
 ___
 
@@ -458,7 +458,7 @@ encodeObject is MsgCreatePoolEncodeObject
 
 #### Defined in
 
-[msg/spot.ts:31](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/msg/spot.ts#L31)
+[msg/spot.ts:31](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/msg/spot.ts#L31)
 
 ___
 
@@ -478,7 +478,7 @@ encodeObject is MsgDonateToEcosystemFundEncodeObject
 
 #### Defined in
 
-[msg/perp.ts:108](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/msg/perp.ts#L108)
+[msg/perp.ts:108](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/msg/perp.ts#L108)
 
 ___
 
@@ -498,7 +498,7 @@ encodeObject is MsgExitPoolEncodeObject
 
 #### Defined in
 
-[msg/spot.ts:53](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/msg/spot.ts#L53)
+[msg/spot.ts:53](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/msg/spot.ts#L53)
 
 ___
 
@@ -518,7 +518,7 @@ encodeObject is MsgJoinPoolEncodeObject
 
 #### Defined in
 
-[msg/spot.ts:42](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/msg/spot.ts#L42)
+[msg/spot.ts:42](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/msg/spot.ts#L42)
 
 ___
 
@@ -538,7 +538,7 @@ encodeObject is MsgMultiLiquidateEncodeObject
 
 #### Defined in
 
-[msg/perp.ts:66](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/msg/perp.ts#L66)
+[msg/perp.ts:66](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/msg/perp.ts#L66)
 
 ___
 
@@ -558,7 +558,7 @@ encodeObject is MsgOpenPositionEncodeObject
 
 #### Defined in
 
-[msg/perp.ts:80](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/msg/perp.ts#L80)
+[msg/perp.ts:80](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/msg/perp.ts#L80)
 
 ___
 
@@ -578,7 +578,7 @@ encodeObject is MsgRemoveMarginEncodeObject
 
 #### Defined in
 
-[msg/perp.ts:52](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/msg/perp.ts#L52)
+[msg/perp.ts:52](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/msg/perp.ts#L52)
 
 ___
 
@@ -598,7 +598,7 @@ encodeObject is MsgSwapAssetsEncodeObject
 
 #### Defined in
 
-[msg/spot.ts:64](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/msg/spot.ts#L64)
+[msg/spot.ts:64](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/msg/spot.ts#L64)
 
 ___
 
@@ -618,7 +618,7 @@ ___
 
 #### Defined in
 
-[chain/chain.ts:134](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/chain/chain.ts#L134)
+[chain/chain.ts:142](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/chain/chain.ts#L142)
 
 ___
 
@@ -638,7 +638,7 @@ ___
 
 #### Defined in
 
-[chain/types.ts:39](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/chain/types.ts#L39)
+[chain/types.ts:39](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/chain/types.ts#L39)
 
 ___
 
@@ -665,7 +665,7 @@ A wallet for protobuf based signing using SIGN_MODE_DIRECT.
 
 #### Defined in
 
-[tx/signer.ts:62](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/tx/signer.ts#L62)
+[tx/signer.ts:62](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/tx/signer.ts#L62)
 
 ___
 
@@ -686,7 +686,7 @@ ___
 
 #### Defined in
 
-[tx/signer.ts:47](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/tx/signer.ts#L47)
+[tx/signer.ts:47](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/tx/signer.ts#L47)
 
 ___
 
@@ -713,7 +713,7 @@ A wallet for protobuf based signing using SIGN_MODE_DIRECT
 
 #### Defined in
 
-[tx/signer.ts:40](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/tx/signer.ts#L40)
+[tx/signer.ts:40](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/tx/signer.ts#L40)
 
 ___
 
@@ -733,7 +733,7 @@ ___
 
 #### Defined in
 
-[chain/chain.ts:123](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/chain/chain.ts#L123)
+[chain/chain.ts:131](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/chain/chain.ts#L131)
 
 ___
 
@@ -762,7 +762,7 @@ ref: Reimplementation of cosmos-sdk/types/decimal.go
 
 #### Defined in
 
-[chain/parse.ts:23](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/chain/parse.ts#L23)
+[chain/parse.ts:23](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/chain/parse.ts#L23)
 
 ___
 
@@ -782,7 +782,7 @@ ___
 
 #### Defined in
 
-[chain/parse.ts:146](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/chain/parse.ts#L146)
+[chain/parse.ts:146](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/chain/parse.ts#L146)
 
 ___
 
@@ -811,4 +811,4 @@ Sends 10 NIBI and 100 NUSD to the given address from the testnet faucet.
 
 #### Defined in
 
-[chain/useFaucet.ts:7](https://github.com/NibiruChain/ts-sdk/blob/f06ff7b1/packages/nibijs/src/chain/useFaucet.ts#L7)
+[chain/useFaucet.ts:15](https://github.com/NibiruChain/ts-sdk/blob/6a4b668/packages/nibijs/src/chain/useFaucet.ts#L15)

--- a/packages/nibijs/package.json
+++ b/packages/nibijs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nibiruchain/nibijs",
   "description": "The TypeScript SDK for the Nibiru blockchain.",
-  "version": "0.19.19",
+  "version": "0.19.20",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/nibijs/src/chain/chain.ts
+++ b/packages/nibijs/src/chain/chain.ts
@@ -1,5 +1,13 @@
-import fetch from "cross-fetch"
+import * as cf from "cross-fetch"
 import { go } from "./types"
+
+declare global {
+  interface Window {
+    fetch: typeof cf.fetch
+  }
+}
+
+window.fetch = cf.fetch
 
 /**
  * Specifies chain information for all endpoints a node exposes such as the

--- a/packages/nibijs/src/chain/chain.ts
+++ b/packages/nibijs/src/chain/chain.ts
@@ -130,7 +130,7 @@ export function Devnet(chainNumber: number): Chain {
 
 export async function queryChainIdWithRest(chain: Chain): Promise<[string, Error?]> {
   const queryChainId = async (chain: Chain): Promise<string> => {
-    const response = await fetch(`${chain.endptRest}/node_info`)
+    const response = await window.fetch(`${chain.endptRest}/node_info`)
     const nodeInfo: { node_info: { network: string } } = await response.json()
     return nodeInfo.node_info.network
   }

--- a/packages/nibijs/src/chain/useFaucet.ts
+++ b/packages/nibijs/src/chain/useFaucet.ts
@@ -1,5 +1,13 @@
-import fetch from "cross-fetch"
+import * as cf from "cross-fetch"
 import { Chain, instanceOfChain } from "./chain"
+
+declare global {
+  interface Window {
+    fetch: typeof cf.fetch
+  }
+}
+
+window.fetch = cf.fetch
 
 /**
  * Sends 10 NIBI and 100 NUSD to the given address from the testnet faucet.

--- a/packages/nibijs/src/chain/useFaucet.ts
+++ b/packages/nibijs/src/chain/useFaucet.ts
@@ -60,17 +60,19 @@ export async function useFaucet({
     `,
   )
 
-  return fetch(faucetUrl, {
-    method: "POST",
-    headers: {
-      Accept: "application/json",
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({ address, coins }),
-  }).catch((err) => {
-    console.error(err)
-    throw err
-  })
+  return window
+    .fetch(faucetUrl, {
+      method: "POST",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ address, coins }),
+    })
+    .catch((err) => {
+      console.error(err)
+      throw err
+    })
 }
 
 /** TODO doc */

--- a/packages/nibijs/src/test/query.test.ts
+++ b/packages/nibijs/src/test/query.test.ts
@@ -1,7 +1,7 @@
 import { Block, GasPrice, coins } from "@cosmjs/stargate"
-import fetch from "cross-fetch"
 import Long from "long"
 import fs from "fs"
+import * as cf from "cross-fetch"
 import { instanceOfError } from "../chain/error"
 import { NibiruQueryClient } from "../query"
 import {
@@ -14,6 +14,14 @@ import {
 } from "./helpers"
 import { newSignerFromMnemonic } from "../tx/signer"
 import { NibiruSigningClient } from "../tx/signingClient"
+
+declare global {
+  interface Window {
+    fetch: typeof cf.fetch
+  }
+}
+
+window.fetch = cf.fetch
 
 interface BlockResp {
   result: { block: any }

--- a/packages/nibijs/src/test/query.test.ts
+++ b/packages/nibijs/src/test/query.test.ts
@@ -35,7 +35,7 @@ describe("connections", () => {
   })
 
   test("tendermint rpc url returns block with GET", async () => {
-    const resp = await fetch(`${TEST_CHAIN.endptTm}/block`)
+    const resp = await window.fetch(`${TEST_CHAIN.endptTm}/block`)
     const respJson = (await resp.json()) as BlockResp
     expect(respJson.result, `respJson: ${respJson}`).toHaveProperty("block")
     const blockJson = respJson.result.block

--- a/yarn.lock
+++ b/yarn.lock
@@ -1402,6 +1402,11 @@
     validate-npm-package-name "^4.0.0"
     yargs-parser "20.2.4"
 
+"@nibiruchain/protojs@^0.19.0":
+  version "0.19.19"
+  resolved "https://registry.yarnpkg.com/@nibiruchain/protojs/-/protojs-0.19.19.tgz#15525d69c6ad44c7e469eada5c01d16e5f714492"
+  integrity sha512-0rFhMiAItTrm2nawyo1lHpjzqcLGS/Avynf4SMoMCDmAthFSQXBWV+Ai4VG8okpjCf4mCWKv23TGzJEphaSxxA==
+
 "@noble/hashes@^1":
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.1.3.tgz#360afc77610e0a61f3417e497dcf36862e4f8111"
@@ -3445,11 +3450,11 @@ create-require@^1.1.0:
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
 cross-fetch@^3.1.5:
-  version "3.1.5"
-  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.5.tgz#e1389f44d9e7ba767907f7af8454787952ab534f"
-  integrity sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.6.tgz#bae05aa31a4da760969756318feeee6e70f15d6c"
+  integrity sha512-riRvo06crlE8HiqOwIpQhxwdOk4fOeR7FVM/wXoxchFEqMNUjvbs3bfo4OTgMEMHzppd4DxFBDbyySj8Cv781g==
   dependencies:
-    node-fetch "2.6.7"
+    node-fetch "^2.6.11"
 
 cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
@@ -7675,6 +7680,13 @@ node-fetch@2.6.7, node-fetch@^2.6.7:
   version "2.6.7"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
   integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
+  dependencies:
+    whatwg-url "^5.0.0"
+
+node-fetch@^2.6.11:
+  version "2.6.11"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.11.tgz#cde7fc71deef3131ef80a738919f999e6edfff25"
+  integrity sha512-4I6pdBY1EthSqDmJkiNk3JIT8cswwR9nfeW/cPdUagJYEQG7R95WRH74wpz7ma8Gh/9dI9FP+OU+0E4FvtA55w==
   dependencies:
     whatwg-url "^5.0.0"
 


### PR DESCRIPTION
- Adds cross fetch as a polyfill for window.fetch | `fetch`
- Necessary for use in the web-app to setup a fetch interceptor for use with Geo-blocking