### PR TITLE
refactor(stableswap): remove token prices

### DIFF
--- a/packages/nibijs/docs/classes/StableSwap.md
+++ b/packages/nibijs/docs/classes/StableSwap.md
@@ -190,7 +190,7 @@ y()
 Calculate x[j] if one makes x[i] = x
 
 Done by solving quadratic equation iteratively.
-x*1**2 + x1 * (sum' - (A*n**n - 1) * D / (A _ n**n)) = D ** (n+1)/(n \*\* (2 _ n) \_ prod' \* A)
+x*1\*\*2 + x1 * (sum' - (A*n\*\*n - 1) * D / (A _ n**n)) = D ** (n+1)/(n \*\* (2 _ n) \_ prod' \* A)
 x_1\*\*2 + b\*x_1 = c
 
 x_1 = (x_1\**2 + c) / (2*x_1 + b)

--- a/packages/nibijs/src/stableswap/stableswap.ts
+++ b/packages/nibijs/src/stableswap/stableswap.ts
@@ -20,33 +20,26 @@ export class StableSwap {
   public Amplification: BigNumber
   public totalTokenSupply: BigNumber[]
   public totalTokensInPool: BigNumber
-  public tokenPrices: BigNumber[]
   public fee: BigNumber
 
   constructor(
     Amplification: BigNumber,
     totalTokenSupply: BigNumber[],
-    tokenPrices: BigNumber[],
     fee: BigNumber
   ) {
     this.Amplification = Amplification
     this.totalTokenSupply = totalTokenSupply
     this.totalTokensInPool = BigNumber(totalTokenSupply.length)
-    this.tokenPrices = tokenPrices
     this.fee = fee
   }
 
   /**
-   * xp() gives an array of total token cap per token
+   * xp() gives an array of total tokens
    *
    * @memberof StableSwap
    */
   xp() {
-    return this.totalTokenSupply.map((x, i) =>
-      BigNumber(x)
-        .multipliedBy(this.tokenPrices[i])
-        .dividedBy(BigNumber(10).exponentiatedBy(BigNumber(18)))
-    )
+    return this.totalTokenSupply.map((x) => BigNumber(x))
   }
 
   /**

--- a/packages/nibijs/src/test/stableswap.test.ts
+++ b/packages/nibijs/src/test/stableswap.test.ts
@@ -26,14 +26,7 @@ describe("stableswap tests", () => {
       const dx = BigNumber(match[5])
       const expectedDy = BigNumber(match[7])
 
-      const curveModel = new StableSwap(
-        amplification,
-        balances,
-        Array(balances.length).fill(
-          BigNumber(10).exponentiatedBy(BigNumber(18))
-        ),
-        BigNumber(0)
-      )
+      const curveModel = new StableSwap(amplification, balances, BigNumber(0))
 
       const dy = curveModel.exchange(send, recv, dx)
       expect(


### PR DESCRIPTION
We don't need token prices when calculating stableswap math.