### PR TITLE
fix(nibijs): NibiruQueryClient must expose methods from the Tendermint client

### DIFF
--- a/packages/nibijs/docs/classes/CustomChain.md
+++ b/packages/nibijs/docs/classes/CustomChain.md
@@ -54,7 +54,7 @@ export const TEST_CHAIN = new CustomChain({
 
 #### Defined in
 
-[chain/chain.ts:56](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/chain/chain.ts#L56)
+[chain/chain.ts:56](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/chain/chain.ts#L56)
 
 ## Properties
 
@@ -70,7 +70,7 @@ chainId: identifier for the chain
 
 #### Defined in
 
-[chain/chain.ts:47](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/chain/chain.ts#L47)
+[chain/chain.ts:47](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/chain/chain.ts#L47)
 
 ---
 
@@ -80,7 +80,7 @@ chainId: identifier for the chain
 
 #### Defined in
 
-[chain/chain.ts:54](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/chain/chain.ts#L54)
+[chain/chain.ts:54](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/chain/chain.ts#L54)
 
 ---
 
@@ -96,7 +96,7 @@ chainName: the name of the chain to display to the user
 
 #### Defined in
 
-[chain/chain.ts:48](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/chain/chain.ts#L48)
+[chain/chain.ts:48](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/chain/chain.ts#L48)
 
 ---
 
@@ -112,7 +112,7 @@ endptGrpc: endpoint for the gRPC gateway. Usually on port 9090.
 
 #### Defined in
 
-[chain/chain.ts:51](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/chain/chain.ts#L51)
+[chain/chain.ts:51](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/chain/chain.ts#L51)
 
 ---
 
@@ -128,7 +128,7 @@ endptRest: endpoint for the REST server. Also, the LCD endpoint.
 
 #### Defined in
 
-[chain/chain.ts:50](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/chain/chain.ts#L50)
+[chain/chain.ts:50](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/chain/chain.ts#L50)
 
 ---
 
@@ -144,7 +144,7 @@ endptTm: endpoint for the Tendermint RPC server. Usually on port 26657.
 
 #### Defined in
 
-[chain/chain.ts:49](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/chain/chain.ts#L49)
+[chain/chain.ts:49](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/chain/chain.ts#L49)
 
 ---
 
@@ -160,7 +160,7 @@ feeDenom: the denomination of the fee to be paid for transactions.
 
 #### Defined in
 
-[chain/chain.ts:52](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/chain/chain.ts#L52)
+[chain/chain.ts:52](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/chain/chain.ts#L52)
 
 ## Methods
 
@@ -174,7 +174,7 @@ feeDenom: the denomination of the fee to be paid for transactions.
 
 #### Defined in
 
-[chain/chain.ts:75](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/chain/chain.ts#L75)
+[chain/chain.ts:75](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/chain/chain.ts#L75)
 
 ---
 
@@ -194,4 +194,4 @@ feeDenom: the denomination of the fee to be paid for transactions.
 
 #### Defined in
 
-[chain/chain.ts:65](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/chain/chain.ts#L65)
+[chain/chain.ts:65](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/chain/chain.ts#L65)

--- a/packages/nibijs/docs/classes/MsgFactory.md
+++ b/packages/nibijs/docs/classes/MsgFactory.md
@@ -27,7 +27,7 @@
 
 #### Defined in
 
-[msg/index.ts:6](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/msg/index.ts#L6)
+[msg/index.ts:6](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/msg/index.ts#L6)
 
 ---
 
@@ -37,4 +37,4 @@
 
 #### Defined in
 
-[msg/index.ts:5](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/msg/index.ts#L5)
+[msg/index.ts:5](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/msg/index.ts#L5)

--- a/packages/nibijs/docs/classes/NibiruQueryClient.md
+++ b/packages/nibijs/docs/classes/NibiruQueryClient.md
@@ -2,6 +2,16 @@
 
 # Class: NibiruQueryClient
 
+Querier for a Nibiru network.
+
+**`Example`**
+
+```ts
+import { NibiruQueryClient, Tesnet } from "@nibiruchain/nibijs"
+const chain = Testnet()
+const querier = await NibiruQueryClient.connect(chain.endptTm)
+```
+
 ## Hierarchy
 
 - `StargateClient`
@@ -17,6 +27,7 @@
 ### Properties
 
 - [nibiruExtensions](NibiruQueryClient.md#nibiruextensions)
+- [tm](NibiruQueryClient.md#tm)
 - [wasmClient](NibiruQueryClient.md#wasmclient)
 
 ### Methods
@@ -45,7 +56,7 @@ StargateClient.constructor
 
 #### Defined in
 
-[query/query.ts:56](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/query/query.ts#L56)
+[query/query.ts:63](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/query/query.ts#L63)
 
 ## Properties
 
@@ -55,7 +66,17 @@ StargateClient.constructor
 
 #### Defined in
 
-[query/query.ts:44](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/query/query.ts#L44)
+[query/query.ts:50](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/query/query.ts#L50)
+
+---
+
+### tm
+
+• `Readonly` **tm**: `Tendermint37Client`
+
+#### Defined in
+
+[query/query.ts:52](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/query/query.ts#L52)
 
 ---
 
@@ -65,7 +86,7 @@ StargateClient.constructor
 
 #### Defined in
 
-[query/query.ts:45](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/query/query.ts#L45)
+[query/query.ts:51](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/query/query.ts#L51)
 
 ## Methods
 
@@ -85,7 +106,7 @@ StargateClient.constructor
 
 #### Defined in
 
-[query/query.ts:80](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/query/query.ts#L80)
+[query/query.ts:89](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/query/query.ts#L89)
 
 ---
 
@@ -99,7 +120,7 @@ StargateClient.constructor
 
 #### Defined in
 
-[query/query.ts:88](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/query/query.ts#L88)
+[query/query.ts:97](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/query/query.ts#L97)
 
 ---
 
@@ -124,4 +145,4 @@ StargateClient.connect
 
 #### Defined in
 
-[query/query.ts:47](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/query/query.ts#L47)
+[query/query.ts:54](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/query/query.ts#L54)

--- a/packages/nibijs/docs/classes/NibiruSigningClient.md
+++ b/packages/nibijs/docs/classes/NibiruSigningClient.md
@@ -46,7 +46,7 @@ SigningStargateClient.constructor
 
 #### Defined in
 
-[tx/signingClient.ts:41](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/tx/signingClient.ts#L41)
+[tx/signingClient.ts:41](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/tx/signingClient.ts#L41)
 
 ## Properties
 
@@ -56,7 +56,7 @@ SigningStargateClient.constructor
 
 #### Defined in
 
-[tx/signingClient.ts:38](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/tx/signingClient.ts#L38)
+[tx/signingClient.ts:38](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/tx/signingClient.ts#L38)
 
 ---
 
@@ -66,7 +66,7 @@ SigningStargateClient.constructor
 
 #### Defined in
 
-[tx/signingClient.ts:39](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/tx/signingClient.ts#L39)
+[tx/signingClient.ts:39](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/tx/signingClient.ts#L39)
 
 ## Methods
 
@@ -86,7 +86,7 @@ SigningStargateClient.constructor
 
 #### Defined in
 
-[tx/signingClient.ts:94](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/tx/signingClient.ts#L94)
+[tx/signingClient.ts:94](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/tx/signingClient.ts#L94)
 
 ---
 
@@ -100,7 +100,7 @@ SigningStargateClient.constructor
 
 #### Defined in
 
-[tx/signingClient.ts:102](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/tx/signingClient.ts#L102)
+[tx/signingClient.ts:102](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/tx/signingClient.ts#L102)
 
 ---
 
@@ -127,4 +127,4 @@ SigningStargateClient.connectWithSigner
 
 #### Defined in
 
-[tx/signingClient.ts:66](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/tx/signingClient.ts#L66)
+[tx/signingClient.ts:66](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/tx/signingClient.ts#L66)

--- a/packages/nibijs/docs/classes/PerpMsgFactory.md
+++ b/packages/nibijs/docs/classes/PerpMsgFactory.md
@@ -55,7 +55,7 @@ Returns a 'TxMessage' for adding margin to a position
 
 #### Defined in
 
-[msg/perp.ts:124](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/msg/perp.ts#L124)
+[msg/perp.ts:124](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/msg/perp.ts#L124)
 
 ---
 
@@ -75,7 +75,7 @@ Returns a 'TxMessage' for adding margin to a position
 
 #### Defined in
 
-[msg/perp.ts:161](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/msg/perp.ts#L161)
+[msg/perp.ts:161](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/msg/perp.ts#L161)
 
 ---
 
@@ -95,7 +95,7 @@ Returns a 'TxMessage' for adding margin to a position
 
 #### Defined in
 
-[msg/perp.ts:175](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/msg/perp.ts#L175)
+[msg/perp.ts:175](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/msg/perp.ts#L175)
 
 ---
 
@@ -115,7 +115,7 @@ Returns a 'TxMessage' for adding margin to a position
 
 #### Defined in
 
-[msg/perp.ts:131](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/msg/perp.ts#L131)
+[msg/perp.ts:131](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/msg/perp.ts#L131)
 
 ---
 
@@ -141,7 +141,7 @@ Returns a 'TxMessage' for adding margin to a position
 
 #### Defined in
 
-[msg/perp.ts:138](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/msg/perp.ts#L138)
+[msg/perp.ts:138](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/msg/perp.ts#L138)
 
 ---
 
@@ -161,7 +161,7 @@ Returns a 'TxMessage' for adding margin to a position
 
 #### Defined in
 
-[msg/perp.ts:168](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/msg/perp.ts#L168)
+[msg/perp.ts:168](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/msg/perp.ts#L168)
 
 ---
 
@@ -181,4 +181,4 @@ Returns a 'TxMessage' for adding margin to a position
 
 #### Defined in
 
-[msg/perp.ts:110](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/msg/perp.ts#L110)
+[msg/perp.ts:110](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/msg/perp.ts#L110)

--- a/packages/nibijs/docs/classes/SpotMsgFactory.md
+++ b/packages/nibijs/docs/classes/SpotMsgFactory.md
@@ -39,7 +39,7 @@
 
 #### Defined in
 
-[msg/spot.ts:61](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/msg/spot.ts#L61)
+[msg/spot.ts:61](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/msg/spot.ts#L61)
 
 ---
 
@@ -59,7 +59,7 @@
 
 #### Defined in
 
-[msg/spot.ts:91](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/msg/spot.ts#L91)
+[msg/spot.ts:91](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/msg/spot.ts#L91)
 
 ---
 
@@ -79,7 +79,7 @@
 
 #### Defined in
 
-[msg/spot.ts:74](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/msg/spot.ts#L74)
+[msg/spot.ts:74](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/msg/spot.ts#L74)
 
 ---
 
@@ -99,4 +99,4 @@
 
 #### Defined in
 
-[msg/spot.ts:102](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/msg/spot.ts#L102)
+[msg/spot.ts:102](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/msg/spot.ts#L102)

--- a/packages/nibijs/docs/classes/StableSwap.md
+++ b/packages/nibijs/docs/classes/StableSwap.md
@@ -54,7 +54,7 @@ Constructor:
 
 #### Defined in
 
-[stableswap/stableswap.ts:25](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/stableswap/stableswap.ts#L25)
+[stableswap/stableswap.ts:25](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/stableswap/stableswap.ts#L25)
 
 ## Properties
 
@@ -64,7 +64,7 @@ Constructor:
 
 #### Defined in
 
-[stableswap/stableswap.ts:20](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/stableswap/stableswap.ts#L20)
+[stableswap/stableswap.ts:20](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/stableswap/stableswap.ts#L20)
 
 ---
 
@@ -74,7 +74,7 @@ Constructor:
 
 #### Defined in
 
-[stableswap/stableswap.ts:23](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/stableswap/stableswap.ts#L23)
+[stableswap/stableswap.ts:23](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/stableswap/stableswap.ts#L23)
 
 ---
 
@@ -84,7 +84,7 @@ Constructor:
 
 #### Defined in
 
-[stableswap/stableswap.ts:21](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/stableswap/stableswap.ts#L21)
+[stableswap/stableswap.ts:21](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/stableswap/stableswap.ts#L21)
 
 ---
 
@@ -94,7 +94,7 @@ Constructor:
 
 #### Defined in
 
-[stableswap/stableswap.ts:22](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/stableswap/stableswap.ts#L22)
+[stableswap/stableswap.ts:22](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/stableswap/stableswap.ts#L22)
 
 ## Methods
 
@@ -117,7 +117,7 @@ StableSwap
 
 #### Defined in
 
-[stableswap/stableswap.ts:54](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/stableswap/stableswap.ts#L54)
+[stableswap/stableswap.ts:54](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/stableswap/stableswap.ts#L54)
 
 ---
 
@@ -145,7 +145,7 @@ StableSwap
 
 #### Defined in
 
-[stableswap/stableswap.ts:143](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/stableswap/stableswap.ts#L143)
+[stableswap/stableswap.ts:143](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/stableswap/stableswap.ts#L143)
 
 ---
 
@@ -165,7 +165,7 @@ StableSwap
 
 #### Defined in
 
-[stableswap/stableswap.ts:41](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/stableswap/stableswap.ts#L41)
+[stableswap/stableswap.ts:41](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/stableswap/stableswap.ts#L41)
 
 ---
 
@@ -178,8 +178,8 @@ y()
 Calculate x[j] if one makes x[i] = x
 
 Done by solving quadratic equation iteratively.
-x*1\*\*2 + x1 * (sum' - (A*n\*\*n - 1) * D / (A _ n**n)) = D ** (n+1)/(n \*\* (2 _ n) \_ prod' \* A)
-x_1\*\*2 + b\*x_1 = c
+x_1**2 + x1 * (sum' - (A*n**n - 1) _ D / (A _ n**n)) = D ** (n+1)/(n ** (2 _ n) _ prod' \* A)
+x_1**2 + b\*x_1 = c
 
 x_1 = (x_1\**2 + c) / (2*x_1 + b)
 
@@ -201,4 +201,4 @@ StableSwap
 
 #### Defined in
 
-[stableswap/stableswap.ts:104](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/stableswap/stableswap.ts#L104)
+[stableswap/stableswap.ts:104](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/stableswap/stableswap.ts#L104)

--- a/packages/nibijs/docs/enums/BECH32_PREFIX.md
+++ b/packages/nibijs/docs/enums/BECH32_PREFIX.md
@@ -23,7 +23,7 @@ ADDR defines the Bech32 prefix of an account address
 
 #### Defined in
 
-[tx/signer.ts:6](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/tx/signer.ts#L6)
+[tx/signer.ts:6](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/tx/signer.ts#L6)
 
 ---
 
@@ -35,7 +35,7 @@ ADDR_VAL defines the Bech32 prefix of an validator's operator address
 
 #### Defined in
 
-[tx/signer.ts:8](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/tx/signer.ts#L8)
+[tx/signer.ts:8](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/tx/signer.ts#L8)
 
 ---
 
@@ -47,7 +47,7 @@ ADDR_VALCONS defines the Bech32 prefix of a consensus node address
 
 #### Defined in
 
-[tx/signer.ts:10](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/tx/signer.ts#L10)
+[tx/signer.ts:10](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/tx/signer.ts#L10)
 
 ---
 
@@ -59,7 +59,7 @@ PUB defines the Bech32 prefix of an account's public key
 
 #### Defined in
 
-[tx/signer.ts:12](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/tx/signer.ts#L12)
+[tx/signer.ts:12](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/tx/signer.ts#L12)
 
 ---
 
@@ -71,7 +71,7 @@ PUB_VAL defines the Bech32 prefix of an validator's operator public key
 
 #### Defined in
 
-[tx/signer.ts:14](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/tx/signer.ts#L14)
+[tx/signer.ts:14](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/tx/signer.ts#L14)
 
 ---
 
@@ -83,4 +83,4 @@ PUB_VALCONS defines the Bech32 prefix of a consensus node public key
 
 #### Defined in
 
-[tx/signer.ts:16](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/tx/signer.ts#L16)
+[tx/signer.ts:16](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/tx/signer.ts#L16)

--- a/packages/nibijs/docs/enums/Signer.md
+++ b/packages/nibijs/docs/enums/Signer.md
@@ -17,7 +17,7 @@
 
 #### Defined in
 
-[tx/signer.ts:53](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/tx/signer.ts#L53)
+[tx/signer.ts:53](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/tx/signer.ts#L53)
 
 ---
 
@@ -27,4 +27,4 @@
 
 #### Defined in
 
-[tx/signer.ts:52](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/tx/signer.ts#L52)
+[tx/signer.ts:52](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/tx/signer.ts#L52)

--- a/packages/nibijs/docs/interfaces/ABCIEvent.md
+++ b/packages/nibijs/docs/interfaces/ABCIEvent.md
@@ -23,7 +23,7 @@ key-value strings of arbitrary data.
 
 #### Defined in
 
-[tx/event.ts:23](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/tx/event.ts#L23)
+[tx/event.ts:23](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/tx/event.ts#L23)
 
 ---
 
@@ -33,4 +33,4 @@ key-value strings of arbitrary data.
 
 #### Defined in
 
-[tx/event.ts:22](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/tx/event.ts#L22)
+[tx/event.ts:22](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/tx/event.ts#L22)

--- a/packages/nibijs/docs/interfaces/Chain.md
+++ b/packages/nibijs/docs/interfaces/Chain.md
@@ -38,7 +38,7 @@ chainId: identifier for the chain
 
 #### Defined in
 
-[chain/chain.ts:21](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/chain/chain.ts#L21)
+[chain/chain.ts:21](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/chain/chain.ts#L21)
 
 ---
 
@@ -50,7 +50,7 @@ chainName: the name of the chain to display to the user
 
 #### Defined in
 
-[chain/chain.ts:23](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/chain/chain.ts#L23)
+[chain/chain.ts:23](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/chain/chain.ts#L23)
 
 ---
 
@@ -62,7 +62,7 @@ endptGrpc: endpoint for the gRPC gateway. Usually on port 9090.
 
 #### Defined in
 
-[chain/chain.ts:19](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/chain/chain.ts#L19)
+[chain/chain.ts:19](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/chain/chain.ts#L19)
 
 ---
 
@@ -74,7 +74,7 @@ endptRest: endpoint for the REST server. Also, the LCD endpoint.
 
 #### Defined in
 
-[chain/chain.ts:17](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/chain/chain.ts#L17)
+[chain/chain.ts:17](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/chain/chain.ts#L17)
 
 ---
 
@@ -86,7 +86,7 @@ endptTm: endpoint for the Tendermint RPC server. Usually on port 26657.
 
 #### Defined in
 
-[chain/chain.ts:15](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/chain/chain.ts#L15)
+[chain/chain.ts:15](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/chain/chain.ts#L15)
 
 ---
 
@@ -98,4 +98,4 @@ feeDenom: the denomination of the fee to be paid for transactions.
 
 #### Defined in
 
-[chain/chain.ts:25](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/chain/chain.ts#L25)
+[chain/chain.ts:25](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/chain/chain.ts#L25)

--- a/packages/nibijs/docs/interfaces/ChainIdParts.md
+++ b/packages/nibijs/docs/interfaces/ChainIdParts.md
@@ -18,7 +18,7 @@
 
 #### Defined in
 
-[chain/chain.ts:31](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/chain/chain.ts#L31)
+[chain/chain.ts:31](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/chain/chain.ts#L31)
 
 ---
 
@@ -28,7 +28,7 @@
 
 #### Defined in
 
-[chain/chain.ts:29](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/chain/chain.ts#L29)
+[chain/chain.ts:29](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/chain/chain.ts#L29)
 
 ---
 
@@ -38,4 +38,4 @@
 
 #### Defined in
 
-[chain/chain.ts:30](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/chain/chain.ts#L30)
+[chain/chain.ts:30](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/chain/chain.ts#L30)

--- a/packages/nibijs/docs/interfaces/EpochsExtension.md
+++ b/packages/nibijs/docs/interfaces/EpochsExtension.md
@@ -16,4 +16,4 @@
 
 #### Defined in
 
-[query/epochs.ts:11](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/query/epochs.ts#L11)
+[query/epochs.ts:11](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/query/epochs.ts#L11)

--- a/packages/nibijs/docs/interfaces/EventAttribute.md
+++ b/packages/nibijs/docs/interfaces/EventAttribute.md
@@ -19,7 +19,7 @@ EventAttribute: A single key-value pair of event data for an ABCI event.
 
 #### Defined in
 
-[tx/event.ts:5](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/tx/event.ts#L5)
+[tx/event.ts:5](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/tx/event.ts#L5)
 
 ---
 
@@ -29,4 +29,4 @@ EventAttribute: A single key-value pair of event data for an ABCI event.
 
 #### Defined in
 
-[tx/event.ts:6](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/tx/event.ts#L6)
+[tx/event.ts:6](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/tx/event.ts#L6)

--- a/packages/nibijs/docs/interfaces/EventMap.md
+++ b/packages/nibijs/docs/interfaces/EventMap.md
@@ -41,4 +41,4 @@ export interface EventTransfer extends EventMap {
 
 #### Defined in
 
-[tx/event.ts:41](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/tx/event.ts#L41)
+[tx/event.ts:41](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/tx/event.ts#L41)

--- a/packages/nibijs/docs/interfaces/InflationExtension.md
+++ b/packages/nibijs/docs/interfaces/InflationExtension.md
@@ -16,4 +16,4 @@
 
 #### Defined in
 
-[query/inflation.ts:19](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/query/inflation.ts#L19)
+[query/inflation.ts:19](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/query/inflation.ts#L19)

--- a/packages/nibijs/docs/interfaces/MsgAddMarginEncodeObject.md
+++ b/packages/nibijs/docs/interfaces/MsgAddMarginEncodeObject.md
@@ -27,7 +27,7 @@ EncodeObject.typeUrl
 
 #### Defined in
 
-[msg/perp.ts:37](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/msg/perp.ts#L37)
+[msg/perp.ts:37](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/msg/perp.ts#L37)
 
 ---
 
@@ -41,4 +41,4 @@ EncodeObject.value
 
 #### Defined in
 
-[msg/perp.ts:38](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/msg/perp.ts#L38)
+[msg/perp.ts:38](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/msg/perp.ts#L38)

--- a/packages/nibijs/docs/interfaces/MsgClosePositionEncodeObject.md
+++ b/packages/nibijs/docs/interfaces/MsgClosePositionEncodeObject.md
@@ -27,7 +27,7 @@ EncodeObject.typeUrl
 
 #### Defined in
 
-[msg/perp.ts:73](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/msg/perp.ts#L73)
+[msg/perp.ts:73](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/msg/perp.ts#L73)
 
 ---
 
@@ -41,4 +41,4 @@ EncodeObject.value
 
 #### Defined in
 
-[msg/perp.ts:74](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/msg/perp.ts#L74)
+[msg/perp.ts:74](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/msg/perp.ts#L74)

--- a/packages/nibijs/docs/interfaces/MsgCreatePoolEncodeObject.md
+++ b/packages/nibijs/docs/interfaces/MsgCreatePoolEncodeObject.md
@@ -27,7 +27,7 @@ EncodeObject.typeUrl
 
 #### Defined in
 
-[msg/spot.ts:27](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/msg/spot.ts#L27)
+[msg/spot.ts:27](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/msg/spot.ts#L27)
 
 ---
 
@@ -41,4 +41,4 @@ EncodeObject.value
 
 #### Defined in
 
-[msg/spot.ts:28](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/msg/spot.ts#L28)
+[msg/spot.ts:28](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/msg/spot.ts#L28)

--- a/packages/nibijs/docs/interfaces/MsgDonateToEcosystemFundEncodeObject.md
+++ b/packages/nibijs/docs/interfaces/MsgDonateToEcosystemFundEncodeObject.md
@@ -27,7 +27,7 @@ EncodeObject.typeUrl
 
 #### Defined in
 
-[msg/perp.ts:82](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/msg/perp.ts#L82)
+[msg/perp.ts:82](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/msg/perp.ts#L82)
 
 ---
 
@@ -41,4 +41,4 @@ EncodeObject.value
 
 #### Defined in
 
-[msg/perp.ts:83](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/msg/perp.ts#L83)
+[msg/perp.ts:83](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/msg/perp.ts#L83)

--- a/packages/nibijs/docs/interfaces/MsgExitPoolEncodeObject.md
+++ b/packages/nibijs/docs/interfaces/MsgExitPoolEncodeObject.md
@@ -27,7 +27,7 @@ EncodeObject.typeUrl
 
 #### Defined in
 
-[msg/spot.ts:43](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/msg/spot.ts#L43)
+[msg/spot.ts:43](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/msg/spot.ts#L43)
 
 ---
 
@@ -41,4 +41,4 @@ EncodeObject.value
 
 #### Defined in
 
-[msg/spot.ts:44](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/msg/spot.ts#L44)
+[msg/spot.ts:44](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/msg/spot.ts#L44)

--- a/packages/nibijs/docs/interfaces/MsgJoinPoolEncodeObject.md
+++ b/packages/nibijs/docs/interfaces/MsgJoinPoolEncodeObject.md
@@ -27,7 +27,7 @@ EncodeObject.typeUrl
 
 #### Defined in
 
-[msg/spot.ts:35](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/msg/spot.ts#L35)
+[msg/spot.ts:35](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/msg/spot.ts#L35)
 
 ---
 
@@ -41,4 +41,4 @@ EncodeObject.value
 
 #### Defined in
 
-[msg/spot.ts:36](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/msg/spot.ts#L36)
+[msg/spot.ts:36](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/msg/spot.ts#L36)

--- a/packages/nibijs/docs/interfaces/MsgMultiLiquidateEncodeObject.md
+++ b/packages/nibijs/docs/interfaces/MsgMultiLiquidateEncodeObject.md
@@ -27,7 +27,7 @@ EncodeObject.typeUrl
 
 #### Defined in
 
-[msg/perp.ts:55](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/msg/perp.ts#L55)
+[msg/perp.ts:55](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/msg/perp.ts#L55)
 
 ---
 
@@ -41,4 +41,4 @@ EncodeObject.value
 
 #### Defined in
 
-[msg/perp.ts:56](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/msg/perp.ts#L56)
+[msg/perp.ts:56](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/msg/perp.ts#L56)

--- a/packages/nibijs/docs/interfaces/MsgOpenPositionEncodeObject.md
+++ b/packages/nibijs/docs/interfaces/MsgOpenPositionEncodeObject.md
@@ -27,7 +27,7 @@ EncodeObject.typeUrl
 
 #### Defined in
 
-[msg/perp.ts:64](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/msg/perp.ts#L64)
+[msg/perp.ts:64](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/msg/perp.ts#L64)
 
 ---
 
@@ -41,4 +41,4 @@ EncodeObject.value
 
 #### Defined in
 
-[msg/perp.ts:65](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/msg/perp.ts#L65)
+[msg/perp.ts:65](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/msg/perp.ts#L65)

--- a/packages/nibijs/docs/interfaces/MsgPartialCloseEncodeObject.md
+++ b/packages/nibijs/docs/interfaces/MsgPartialCloseEncodeObject.md
@@ -27,7 +27,7 @@ EncodeObject.typeUrl
 
 #### Defined in
 
-[msg/perp.ts:93](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/msg/perp.ts#L93)
+[msg/perp.ts:93](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/msg/perp.ts#L93)
 
 ---
 
@@ -41,4 +41,4 @@ EncodeObject.value
 
 #### Defined in
 
-[msg/perp.ts:94](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/msg/perp.ts#L94)
+[msg/perp.ts:94](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/msg/perp.ts#L94)

--- a/packages/nibijs/docs/interfaces/MsgRemoveMarginEncodeObject.md
+++ b/packages/nibijs/docs/interfaces/MsgRemoveMarginEncodeObject.md
@@ -27,7 +27,7 @@ EncodeObject.typeUrl
 
 #### Defined in
 
-[msg/perp.ts:46](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/msg/perp.ts#L46)
+[msg/perp.ts:46](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/msg/perp.ts#L46)
 
 ---
 
@@ -41,4 +41,4 @@ EncodeObject.value
 
 #### Defined in
 
-[msg/perp.ts:47](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/msg/perp.ts#L47)
+[msg/perp.ts:47](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/msg/perp.ts#L47)

--- a/packages/nibijs/docs/interfaces/MsgSwapAssetsEncodeObject.md
+++ b/packages/nibijs/docs/interfaces/MsgSwapAssetsEncodeObject.md
@@ -27,7 +27,7 @@ EncodeObject.typeUrl
 
 #### Defined in
 
-[msg/spot.ts:51](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/msg/spot.ts#L51)
+[msg/spot.ts:51](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/msg/spot.ts#L51)
 
 ---
 
@@ -41,4 +41,4 @@ EncodeObject.value
 
 #### Defined in
 
-[msg/spot.ts:52](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/msg/spot.ts#L52)
+[msg/spot.ts:52](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/msg/spot.ts#L52)

--- a/packages/nibijs/docs/interfaces/OracleExtension.md
+++ b/packages/nibijs/docs/interfaces/OracleExtension.md
@@ -16,4 +16,4 @@
 
 #### Defined in
 
-[query/oracle.ts:37](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/query/oracle.ts#L37)
+[query/oracle.ts:37](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/query/oracle.ts#L37)

--- a/packages/nibijs/docs/interfaces/PageRequest.md
+++ b/packages/nibijs/docs/interfaces/PageRequest.md
@@ -34,7 +34,7 @@ is set.
 
 #### Defined in
 
-[query/spot.ts:252](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/query/spot.ts#L252)
+[query/spot.ts:252](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/query/spot.ts#L252)
 
 ---
 
@@ -48,7 +48,7 @@ should be set.
 
 #### Defined in
 
-[query/spot.ts:234](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/query/spot.ts#L234)
+[query/spot.ts:234](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/query/spot.ts#L234)
 
 ---
 
@@ -61,7 +61,7 @@ If left empty it will default to a value to be set by each app.
 
 #### Defined in
 
-[query/spot.ts:245](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/query/spot.ts#L245)
+[query/spot.ts:245](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/query/spot.ts#L245)
 
 ---
 
@@ -75,7 +75,7 @@ be set.
 
 #### Defined in
 
-[query/spot.ts:240](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/query/spot.ts#L240)
+[query/spot.ts:240](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/query/spot.ts#L240)
 
 ---
 
@@ -89,4 +89,4 @@ Since: cosmos-sdk 0.43
 
 #### Defined in
 
-[query/spot.ts:258](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/query/spot.ts#L258)
+[query/spot.ts:258](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/query/spot.ts#L258)

--- a/packages/nibijs/docs/interfaces/PerpExtension.md
+++ b/packages/nibijs/docs/interfaces/PerpExtension.md
@@ -16,4 +16,4 @@
 
 #### Defined in
 
-[query/perp.ts:24](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/query/perp.ts#L24)
+[query/perp.ts:24](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/query/perp.ts#L24)

--- a/packages/nibijs/docs/interfaces/SpotExtension.md
+++ b/packages/nibijs/docs/interfaces/SpotExtension.md
@@ -16,4 +16,4 @@
 
 #### Defined in
 
-[query/spot.ts:58](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/query/spot.ts#L58)
+[query/spot.ts:58](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/query/spot.ts#L58)

--- a/packages/nibijs/docs/interfaces/SudoExtension.md
+++ b/packages/nibijs/docs/interfaces/SudoExtension.md
@@ -16,4 +16,4 @@
 
 #### Defined in
 
-[query/sudo.ts:9](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/query/sudo.ts#L9)
+[query/sudo.ts:9](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/query/sudo.ts#L9)

--- a/packages/nibijs/docs/interfaces/TxLog.md
+++ b/packages/nibijs/docs/interfaces/TxLog.md
@@ -16,4 +16,4 @@
 
 #### Defined in
 
-[chain/types.ts:53](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/chain/types.ts#L53)
+[chain/types.ts:53](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/chain/types.ts#L53)

--- a/packages/nibijs/docs/modules.md
+++ b/packages/nibijs/docs/modules.md
@@ -112,11 +112,11 @@
 
 ### NibiruExtensions
 
-Ƭ **NibiruExtensions**: `QueryClient` & [`SpotExtension`](interfaces/SpotExtension.md) & [`PerpExtension`](interfaces/PerpExtension.md) & [`SudoExtension`](interfaces/SudoExtension.md) & [`InflationExtension`](interfaces/InflationExtension.md) & [`OracleExtension`](interfaces/OracleExtension.md) & [`EpochsExtension`](interfaces/EpochsExtension.md) & `DistributionExtension` & `GovExtension` & `StakingExtension` & `IbcExtension` & `WasmExtension` & `AuthExtension`
+Ƭ **NibiruExtensions**: `StargateQueryClient` & [`SpotExtension`](interfaces/SpotExtension.md) & [`PerpExtension`](interfaces/PerpExtension.md) & [`SudoExtension`](interfaces/SudoExtension.md) & [`InflationExtension`](interfaces/InflationExtension.md) & [`OracleExtension`](interfaces/OracleExtension.md) & [`EpochsExtension`](interfaces/EpochsExtension.md) & `DistributionExtension` & `GovExtension` & `StakingExtension` & `IbcExtension` & `WasmExtension` & `AuthExtension`
 
 #### Defined in
 
-[query/query.ts:29](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/query/query.ts#L29)
+[query/query.ts:29](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/query/query.ts#L29)
 
 ## Variables
 
@@ -126,7 +126,7 @@
 
 #### Defined in
 
-[chain/parse.ts:2](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/chain/parse.ts#L2)
+[chain/parse.ts:2](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/chain/parse.ts#L2)
 
 ---
 
@@ -141,7 +141,7 @@ controllable, isolated development environment for testing purposes.
 
 #### Defined in
 
-[chain/chain.ts:85](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/chain/chain.ts#L85)
+[chain/chain.ts:85](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/chain/chain.ts#L85)
 
 ---
 
@@ -151,7 +151,7 @@ controllable, isolated development environment for testing purposes.
 
 #### Defined in
 
-[msg/index.ts:9](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/msg/index.ts#L9)
+[msg/index.ts:9](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/msg/index.ts#L9)
 
 ---
 
@@ -173,7 +173,7 @@ controllable, isolated development environment for testing purposes.
 
 #### Defined in
 
-[msg/perp.ts:16](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/msg/perp.ts#L16)
+[msg/perp.ts:16](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/msg/perp.ts#L16)
 
 ---
 
@@ -192,7 +192,7 @@ controllable, isolated development environment for testing purposes.
 
 #### Defined in
 
-[msg/spot.ts:12](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/msg/spot.ts#L12)
+[msg/spot.ts:12](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/msg/spot.ts#L12)
 
 ---
 
@@ -202,7 +202,7 @@ controllable, isolated development environment for testing purposes.
 
 #### Defined in
 
-[tx/signingClient.ts:31](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/tx/signingClient.ts#L31)
+[tx/signingClient.ts:31](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/tx/signingClient.ts#L31)
 
 ---
 
@@ -212,7 +212,7 @@ controllable, isolated development environment for testing purposes.
 
 #### Defined in
 
-[msg/perp.ts:26](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/msg/perp.ts#L26)
+[msg/perp.ts:26](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/msg/perp.ts#L26)
 
 ---
 
@@ -222,7 +222,7 @@ controllable, isolated development environment for testing purposes.
 
 #### Defined in
 
-[msg/spot.ts:19](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/msg/spot.ts#L19)
+[msg/spot.ts:19](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/msg/spot.ts#L19)
 
 ## Functions
 
@@ -246,7 +246,7 @@ dev team to live-test new features before official public release.
 
 #### Defined in
 
-[chain/chain.ts:124](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/chain/chain.ts#L124)
+[chain/chain.ts:124](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/chain/chain.ts#L124)
 
 ---
 
@@ -275,7 +275,7 @@ Testnet - Permanent Nibiru public test network.
 
 #### Defined in
 
-[chain/chain.ts:106](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/chain/chain.ts#L106)
+[chain/chain.ts:106](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/chain/chain.ts#L106)
 
 ---
 
@@ -308,7 +308,7 @@ arguments are passed.
 
 #### Defined in
 
-[chain/chain.ts:106](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/chain/chain.ts#L106)
+[chain/chain.ts:106](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/chain/chain.ts#L106)
 
 ---
 
@@ -329,7 +329,7 @@ arguments are passed.
 
 #### Defined in
 
-[chain/types.ts:29](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/chain/types.ts#L29)
+[chain/types.ts:29](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/chain/types.ts#L29)
 
 ---
 
@@ -353,7 +353,7 @@ a ChainIdParts object
 
 #### Defined in
 
-[chain/chain.ts:157](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/chain/chain.ts#L157)
+[chain/chain.ts:157](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/chain/chain.ts#L157)
 
 ---
 
@@ -375,7 +375,7 @@ eventToMap: Converts an ABCIEvent into an EventMap.
 
 #### Defined in
 
-[tx/event.ts:44](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/tx/event.ts#L44)
+[tx/event.ts:44](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/tx/event.ts#L44)
 
 ---
 
@@ -397,7 +397,7 @@ Constructs a faucet URL from a Chain object.
 
 #### Defined in
 
-[chain/useFaucet.ts:59](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/chain/useFaucet.ts#L59)
+[chain/useFaucet.ts:59](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/chain/useFaucet.ts#L59)
 
 ---
 
@@ -421,7 +421,7 @@ events of known type are present.
 
 #### Defined in
 
-[tx/event.ts:54](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/tx/event.ts#L54)
+[tx/event.ts:54](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/tx/event.ts#L54)
 
 ---
 
@@ -461,7 +461,7 @@ the human-readbale Dec.
 
 #### Defined in
 
-[chain/parse.ts:113](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/chain/parse.ts#L113)
+[chain/parse.ts:113](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/chain/parse.ts#L113)
 
 ---
 
@@ -481,7 +481,7 @@ the human-readbale Dec.
 
 #### Defined in
 
-[chain/parse.ts:164](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/chain/parse.ts#L164)
+[chain/parse.ts:164](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/chain/parse.ts#L164)
 
 ---
 
@@ -495,7 +495,7 @@ the human-readbale Dec.
 
 #### Defined in
 
-[tx/signer.ts:19](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/tx/signer.ts#L19)
+[tx/signer.ts:19](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/tx/signer.ts#L19)
 
 ---
 
@@ -530,7 +530,7 @@ GoError: A wrapped error type resulting from a "throw" inside a Promise.
 
 #### Defined in
 
-[chain/types.ts:14](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/chain/types.ts#L14)
+[chain/types.ts:14](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/chain/types.ts#L14)
 
 ---
 
@@ -550,7 +550,7 @@ GoError: A wrapped error type resulting from a "throw" inside a Promise.
 
 #### Defined in
 
-[msg/perp.ts:41](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/msg/perp.ts#L41)
+[msg/perp.ts:41](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/msg/perp.ts#L41)
 
 ---
 
@@ -570,7 +570,7 @@ GoError: A wrapped error type resulting from a "throw" inside a Promise.
 
 #### Defined in
 
-[msg/perp.ts:77](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/msg/perp.ts#L77)
+[msg/perp.ts:77](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/msg/perp.ts#L77)
 
 ---
 
@@ -590,7 +590,7 @@ GoError: A wrapped error type resulting from a "throw" inside a Promise.
 
 #### Defined in
 
-[msg/spot.ts:31](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/msg/spot.ts#L31)
+[msg/spot.ts:31](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/msg/spot.ts#L31)
 
 ---
 
@@ -610,7 +610,7 @@ GoError: A wrapped error type resulting from a "throw" inside a Promise.
 
 #### Defined in
 
-[msg/perp.ts:86](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/msg/perp.ts#L86)
+[msg/perp.ts:86](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/msg/perp.ts#L86)
 
 ---
 
@@ -630,7 +630,7 @@ GoError: A wrapped error type resulting from a "throw" inside a Promise.
 
 #### Defined in
 
-[msg/spot.ts:47](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/msg/spot.ts#L47)
+[msg/spot.ts:47](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/msg/spot.ts#L47)
 
 ---
 
@@ -650,7 +650,7 @@ GoError: A wrapped error type resulting from a "throw" inside a Promise.
 
 #### Defined in
 
-[msg/spot.ts:39](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/msg/spot.ts#L39)
+[msg/spot.ts:39](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/msg/spot.ts#L39)
 
 ---
 
@@ -670,7 +670,7 @@ GoError: A wrapped error type resulting from a "throw" inside a Promise.
 
 #### Defined in
 
-[msg/perp.ts:59](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/msg/perp.ts#L59)
+[msg/perp.ts:59](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/msg/perp.ts#L59)
 
 ---
 
@@ -690,7 +690,7 @@ GoError: A wrapped error type resulting from a "throw" inside a Promise.
 
 #### Defined in
 
-[msg/perp.ts:68](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/msg/perp.ts#L68)
+[msg/perp.ts:68](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/msg/perp.ts#L68)
 
 ---
 
@@ -710,7 +710,7 @@ GoError: A wrapped error type resulting from a "throw" inside a Promise.
 
 #### Defined in
 
-[msg/perp.ts:97](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/msg/perp.ts#L97)
+[msg/perp.ts:97](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/msg/perp.ts#L97)
 
 ---
 
@@ -730,7 +730,7 @@ GoError: A wrapped error type resulting from a "throw" inside a Promise.
 
 #### Defined in
 
-[msg/perp.ts:50](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/msg/perp.ts#L50)
+[msg/perp.ts:50](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/msg/perp.ts#L50)
 
 ---
 
@@ -750,7 +750,7 @@ GoError: A wrapped error type resulting from a "throw" inside a Promise.
 
 #### Defined in
 
-[msg/spot.ts:55](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/msg/spot.ts#L55)
+[msg/spot.ts:55](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/msg/spot.ts#L55)
 
 ---
 
@@ -773,7 +773,7 @@ the network and endpoint are active.
 
 #### Defined in
 
-[chain/chain.ts:147](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/chain/chain.ts#L147)
+[chain/chain.ts:147](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/chain/chain.ts#L147)
 
 ---
 
@@ -793,7 +793,7 @@ the network and endpoint are active.
 
 #### Defined in
 
-[chain/types.ts:44](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/chain/types.ts#L44)
+[chain/types.ts:44](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/chain/types.ts#L44)
 
 ---
 
@@ -820,7 +820,7 @@ A wallet for protobuf based signing using SIGN_MODE_DIRECT.
 
 #### Defined in
 
-[tx/signer.ts:45](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/tx/signer.ts#L45)
+[tx/signer.ts:45](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/tx/signer.ts#L45)
 
 ---
 
@@ -847,7 +847,7 @@ A wallet for protobuf based signing using SIGN_MODE_DIRECT
 
 #### Defined in
 
-[tx/signer.ts:29](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/tx/signer.ts#L29)
+[tx/signer.ts:29](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/tx/signer.ts#L29)
 
 ---
 
@@ -877,7 +877,7 @@ const eventLogs = parseEventLogs(txResp)
 
 #### Defined in
 
-[tx/event.ts:67](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/tx/event.ts#L67)
+[tx/event.ts:67](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/tx/event.ts#L67)
 
 ---
 
@@ -897,7 +897,7 @@ const eventLogs = parseEventLogs(txResp)
 
 #### Defined in
 
-[chain/chain.ts:131](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/chain/chain.ts#L131)
+[chain/chain.ts:131](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/chain/chain.ts#L131)
 
 ---
 
@@ -917,7 +917,7 @@ const eventLogs = parseEventLogs(txResp)
 
 #### Defined in
 
-[query/epochs.ts:19](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/query/epochs.ts#L19)
+[query/epochs.ts:19](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/query/epochs.ts#L19)
 
 ---
 
@@ -937,7 +937,7 @@ const eventLogs = parseEventLogs(txResp)
 
 #### Defined in
 
-[query/inflation.ts:29](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/query/inflation.ts#L29)
+[query/inflation.ts:29](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/query/inflation.ts#L29)
 
 ---
 
@@ -957,7 +957,7 @@ const eventLogs = parseEventLogs(txResp)
 
 #### Defined in
 
-[query/oracle.ts:91](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/query/oracle.ts#L91)
+[query/oracle.ts:91](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/query/oracle.ts#L91)
 
 ---
 
@@ -977,7 +977,7 @@ const eventLogs = parseEventLogs(txResp)
 
 #### Defined in
 
-[query/perp.ts:45](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/query/perp.ts#L45)
+[query/perp.ts:45](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/query/perp.ts#L45)
 
 ---
 
@@ -997,7 +997,7 @@ const eventLogs = parseEventLogs(txResp)
 
 #### Defined in
 
-[query/spot.ts:102](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/query/spot.ts#L102)
+[query/spot.ts:102](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/query/spot.ts#L102)
 
 ---
 
@@ -1017,7 +1017,7 @@ const eventLogs = parseEventLogs(txResp)
 
 #### Defined in
 
-[query/sudo.ts:14](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/query/sudo.ts#L14)
+[query/sudo.ts:14](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/query/sudo.ts#L14)
 
 ---
 
@@ -1064,7 +1064,7 @@ sdk.Dec protobuf string into a number.
 
 #### Defined in
 
-[chain/parse.ts:30](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/chain/parse.ts#L30)
+[chain/parse.ts:30](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/chain/parse.ts#L30)
 
 ---
 
@@ -1084,7 +1084,7 @@ sdk.Dec protobuf string into a number.
 
 #### Defined in
 
-[chain/parse.ts:162](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/chain/parse.ts#L162)
+[chain/parse.ts:162](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/chain/parse.ts#L162)
 
 ---
 
@@ -1104,7 +1104,7 @@ sdk.Dec protobuf string into a number.
 
 #### Defined in
 
-[query/spot.ts:49](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/query/spot.ts#L49)
+[query/spot.ts:49](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/query/spot.ts#L49)
 
 ---
 
@@ -1124,7 +1124,7 @@ sdk.Dec protobuf string into a number.
 
 #### Defined in
 
-[query/spot.ts:41](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/query/spot.ts#L41)
+[query/spot.ts:41](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/query/spot.ts#L41)
 
 ---
 
@@ -1153,4 +1153,4 @@ Sends 11 NIBI, 100 NUSD, and 100 USDT to the given address from the testnet fauc
 
 #### Defined in
 
-[chain/useFaucet.ts:7](https://github.com/NibiruChain/ts-sdk/blob/8fe02e0/packages/nibijs/src/chain/useFaucet.ts#L7)
+[chain/useFaucet.ts:7](https://github.com/NibiruChain/ts-sdk/blob/d2a4311/packages/nibijs/src/chain/useFaucet.ts#L7)

--- a/packages/nibijs/src/query/query.ts
+++ b/packages/nibijs/src/query/query.ts
@@ -3,7 +3,7 @@ import {
   DistributionExtension,
   GovExtension,
   IbcExtension,
-  QueryClient,
+  QueryClient as StargateQueryClient,
   setupAuthExtension,
   setupDistributionExtension,
   setupGovExtension,
@@ -26,7 +26,7 @@ import { setupSpotExtension, SpotExtension } from "./spot"
 import { setupSudoExtension, SudoExtension } from "./sudo"
 import { InflationExtension, setupInflationExtension } from "./inflation"
 
-export type NibiruExtensions = QueryClient &
+export type NibiruExtensions = StargateQueryClient &
   SpotExtension &
   PerpExtension &
   SudoExtension &
@@ -40,9 +40,16 @@ export type NibiruExtensions = QueryClient &
   WasmExtension &
   AuthExtension
 
+/** Querier for a Nibiru network.
+ * @example
+ * import { NibiruQueryClient, Tesnet } from "@nibiruchain/nibijs"
+ * const chain = Testnet()
+ * const querier = await NibiruQueryClient.connect(chain.endptTm)
+ * */
 export class NibiruQueryClient extends StargateClient {
   public readonly nibiruExtensions: NibiruExtensions
   public readonly wasmClient: CosmWasmClient
+  public readonly tm: Tendermint37Client
 
   public static async connect(
     endpoint: string,
@@ -60,7 +67,9 @@ export class NibiruQueryClient extends StargateClient {
   ) {
     super(tmClient, options)
     this.wasmClient = wasmClient
-    this.nibiruExtensions = QueryClient.withExtensions(
+    // Because the StargateQueryClient doesn't include methods from the TM client
+    this.tm = tmClient
+    this.nibiruExtensions = StargateQueryClient.withExtensions(
       tmClient,
       setupEpochsExtension,
       setupOracleExtension,


### PR DESCRIPTION
Functions for querying by tx hash or block are not available by default on the `QueryClient` from `cosmjs/stargate`  (`NibiruExtensions` in our case). They
are instead of a part of the `Tendermint37Client`. 

The `NibiruQueryClient` needs to include the Tendermint client as a `readonly` field like the `wasmClient`. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated documentation to reflect the renaming of `QueryClient` to `StargateQueryClient`.
  - Added documentation for the new `tm` property in the `NibiruQueryClient` class.

- **New Features**
  - Introduced a new `tm` property of type `Tendermint37Client` to the `NibiruQueryClient` class for enhanced query capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->