### PR TITLE
refactor: custom chain for mainnet

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -194,5 +194,6 @@ module.exports = function (root = __dirname) {
     // Whether to use watchman for file crawling
     // watchman: true,
     testTimeout: 120000,
+    openHandlesTimeout: 2000,
   }
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -194,6 +194,5 @@ module.exports = function (root = __dirname) {
     // Whether to use watchman for file crawling
     // watchman: true,
     testTimeout: 120000,
-    openHandlesTimeout: 2000,
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "clean": "lerna run --parallel clean",
     "commit": "cz",
     "publish:all": "lerna publish from-package",
-    "test": "jest --verbose --detectOpenHandles",
+    "test": "jest --verbose --detectOpenHandles --watchAll --no-cache",
     "lint": "eslint -c './.eslintrc.js' './packages/**/*.{ts,js}'",
     "lint:ci": "yarn lint . --format junit",
     "lint:md": "markdownlint --ignore node_modules --ignore .git",

--- a/packages/nibijs/docs/classes/StableSwap.md
+++ b/packages/nibijs/docs/classes/StableSwap.md
@@ -178,7 +178,7 @@ y()
 Calculate x[j] if one makes x[i] = x
 
 Done by solving quadratic equation iteratively.
-x*1**2 + x1 * (sum' - (A*n**n - 1) * D / (A _ n**n)) = D ** (n+1)/(n \*\* (2 _ n) \_ prod' \* A)
+x*1\*\*2 + x1 * (sum' - (A*n\*\*n - 1) * D / (A _ n**n)) = D ** (n+1)/(n \*\* (2 _ n) \_ prod' \* A)
 x_1\*\*2 + b\*x_1 = c
 
 x_1 = (x_1\**2 + c) / (2*x_1 + b)

--- a/packages/nibijs/docs/classes/StableSwap.md
+++ b/packages/nibijs/docs/classes/StableSwap.md
@@ -178,8 +178,8 @@ y()
 Calculate x[j] if one makes x[i] = x
 
 Done by solving quadratic equation iteratively.
-x_1**2 + x1 * (sum' - (A*n**n - 1) _ D / (A _ n**n)) = D ** (n+1)/(n ** (2 _ n) _ prod' \* A)
-x_1**2 + b\*x_1 = c
+x*1**2 + x1 * (sum' - (A*n**n - 1) * D / (A _ n**n)) = D ** (n+1)/(n \*\* (2 _ n) \_ prod' \* A)
+x_1\*\*2 + b\*x_1 = c
 
 x_1 = (x_1\**2 + c) / (2*x_1 + b)
 

--- a/packages/nibijs/src/chain/chain.ts
+++ b/packages/nibijs/src/chain/chain.ts
@@ -26,9 +26,10 @@ export interface Chain {
 }
 
 export interface ChainIdParts {
-  prefix: string // e.g. `nibiru`
+  prefix?: string // e.g. `nibiru`
   shortName: string // e.g. `itn`
   number: number // e.g. `1`
+  mainnet?: boolean
 }
 
 /** CustomChain is a convenience class for intializing the endpoints of a chain
@@ -57,9 +58,14 @@ export class CustomChain implements Chain {
     this.chainIdParts = chainIdParts
     this.chainId = this.initChainId()
     this.chainName = this.chainId
-    this.endptTm = `https://rpc.${chainIdParts.shortName}-${chainIdParts.number}.nibiru.fi`
-    this.endptRest = `https://lcd.${chainIdParts.shortName}-${chainIdParts.number}.nibiru.fi`
-    this.endptGrpc = `grpc.${chainIdParts.shortName}-${chainIdParts.number}.nibiru.fi`
+
+    const chainEndpt = chainIdParts.mainnet
+      ? ""
+      : `.${chainIdParts.shortName}-${chainIdParts.number}`
+
+    this.endptTm = `https://rpc${chainEndpt}.nibiru.fi`
+    this.endptRest = `https://lcd${chainEndpt}.nibiru.fi`
+    this.endptGrpc = `grpc${chainEndpt}.nibiru.fi`
   }
 
   public static fromChainId(chainId: string): Chain {
@@ -74,7 +80,7 @@ export class CustomChain implements Chain {
 
   private initChainId = () => {
     const { prefix, shortName, number } = this.chainIdParts
-    return [prefix, shortName, number].join("-")
+    return [prefix, shortName, number].filter(Boolean).join("-")
   }
 }
 

--- a/packages/nibijs/src/test/chain.test.ts
+++ b/packages/nibijs/src/test/chain.test.ts
@@ -50,6 +50,22 @@ describe("chain/chain", () => {
     expectCreatedChain(result, "devnet")
   })
 
+  test("Mainnet", () => {
+    const shortName = "cataclysm"
+    const number = 1
+    const result = new CustomChain({
+      shortName,
+      number,
+      mainnet: true,
+    })
+    expect(result.chainId).toEqual(`${shortName}-${number}`)
+    expect(result.chainName).toEqual(`${shortName}-${number}`)
+    expect(result.endptGrpc).toEqual(`grpc.nibiru.fi`)
+    expect(result.endptRest).toEqual(`https://lcd.nibiru.fi`)
+    expect(result.endptTm).toEqual(`https://rpc.nibiru.fi`)
+    expect(result.feeDenom).toEqual(`unibi`)
+  })
+
   test("queryChainIdWithRest", async () => {
     const chain = Devnet(2)
     const result = await queryChainIdWithRest(chain)


### PR DESCRIPTION
Bringing back https://github.com/NibiruChain/ts-sdk/pull/249 for mainnet, this replaces a lot of custom string url manipulations in https://github.com/NibiruChain/web-app/pull/813