### PR TITLE
refactor: ../.. instead of src

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -12,6 +12,6 @@ yarn build:tsc
 echo "Fix path resolution"
 dist_folder="./dist"
 # Go through all ts and js files in the dist folder
-find "$dist_folder" -type f \( -name "*.ts" -o -name "*.js" \) -exec sed -i 's|require("@/|require("../../|g' {} +
+find "$dist_folder" -type f \( -name "*.ts" -o -name "*.js" \) -exec sed -i 's|require("@/|require("src/|g' {} +
 
 # yarn docgen

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -12,7 +12,6 @@ yarn build:tsc
 echo "Fix path resolution"
 dist_folder="./dist"
 # Go through all ts and js files in the dist folder
-find "$dist_folder" -type f \( -name "*.ts" -o -name "*.js" \) -exec sed -i 's|require("@/|require("src/|g' {} +
-
+find "$dist_folder" -type f \( -name "*.ts" -o -name "*.js" \) -exec sed -i 's|require("@/|require("../../|g' {} +
 
 # yarn docgen

--- a/src/sdk/msg/perp.ts
+++ b/src/sdk/msg/perp.ts
@@ -7,8 +7,8 @@ import {
   MsgMarketOrder,
   MsgRemoveMargin,
   MsgPartialClose,
-} from "@/protojs/nibiru/perp/v2/tx"
-import { Direction } from "@/protojs/nibiru/perp/v2/state"
+} from "../../protojs/nibiru/perp/v2/tx"
+import { Direction } from "../../protojs/nibiru/perp/v2/state"
 import { toSdkDec, toSdkInt } from "../chain"
 import { TxMessage } from "./encode-types"
 

--- a/src/sdk/msg/spot.ts
+++ b/src/sdk/msg/spot.ts
@@ -4,7 +4,7 @@ import {
   MsgExitPool,
   MsgJoinPool,
   MsgSwapAssets,
-} from "@/protojs/nibiru/spot/v1/tx"
+} from "../../protojs/nibiru/spot/v1/tx"
 import { TxMessage } from "./encode-types"
 import { toSdkDec } from "../chain"
 

--- a/src/sdk/query/epochs.ts
+++ b/src/sdk/query/epochs.ts
@@ -5,7 +5,7 @@ import {
   QueryCurrentEpochResponse,
   QueryEpochsInfoRequest,
   QueryEpochsInfoResponse,
-} from "@/protojs/nibiru/epochs/v1/query"
+} from "../../protojs/nibiru/epochs/v1/query"
 
 export interface EpochsExtension {
   readonly epochs: Readonly<{

--- a/src/sdk/query/inflation.ts
+++ b/src/sdk/query/inflation.ts
@@ -13,7 +13,7 @@ import {
   QueryPeriodResponse,
   QuerySkippedEpochsRequest,
   QuerySkippedEpochsResponse,
-} from "@/protojs/nibiru/inflation/v1/query"
+} from "../../protojs/nibiru/inflation/v1/query"
 
 export interface InflationExtension {
   readonly inflation: Readonly<{

--- a/src/sdk/query/oracle.ts
+++ b/src/sdk/query/oracle.ts
@@ -26,11 +26,11 @@ import {
   QueryParamsResponse,
   QueryVoteTargetsRequest,
   QueryVoteTargetsResponse,
-} from "@/protojs/nibiru/oracle/v1/query"
+} from "../../protojs/nibiru/oracle/v1/query"
 import {
   AggregateExchangeRatePrevote,
   AggregateExchangeRateVote,
-} from "@/protojs/nibiru/oracle/v1/oracle"
+} from "../../protojs/nibiru/oracle/v1/oracle"
 import { fromSdkDec } from "../chain"
 
 export interface OracleExtension {

--- a/src/sdk/query/perp.ts
+++ b/src/sdk/query/perp.ts
@@ -9,7 +9,7 @@ import {
   QueryPositionResponse,
   QueryPositionsRequest,
   QueryPositionsResponse,
-} from "@/protojs/nibiru/perp/v2/query"
+} from "../../protojs/nibiru/perp/v2/query"
 import { fromSdkDec } from "../chain"
 
 function transformPosition(resp: QueryPositionResponse): QueryPositionResponse {

--- a/src/sdk/query/spot.ts
+++ b/src/sdk/query/spot.ts
@@ -1,6 +1,6 @@
 import { createProtobufRpcClient, QueryClient } from "@cosmjs/stargate"
 import { Coin } from "@cosmjs/proto-signing"
-import { Pool, PoolParams } from "@/protojs/nibiru/spot/v1/pool"
+import { Pool, PoolParams } from "../../protojs/nibiru/spot/v1/pool"
 import {
   QueryClientImpl as SpotQueryClientImpl,
   QueryExitExactAmountInRequest,
@@ -35,7 +35,7 @@ import {
   QueryTotalPoolLiquidityResponse,
   QueryTotalSharesRequest,
   QueryTotalSharesResponse,
-} from "@/protojs/nibiru/spot/v1/query"
+} from "../../protojs/nibiru/spot/v1/query"
 import { fromSdkDec } from "../chain"
 
 export const transformPoolParams = (pp?: PoolParams) => {

--- a/src/sdk/query/sudo.ts
+++ b/src/sdk/query/sudo.ts
@@ -3,7 +3,7 @@ import {
   QueryClientImpl,
   QuerySudoersRequest,
   QuerySudoersResponse,
-} from "@/protojs/nibiru/sudo/v1/query"
+} from "../../protojs/nibiru/sudo/v1/query"
 
 export interface SudoExtension {
   readonly sudo: Readonly<{


### PR DESCRIPTION
`src/..` gave me the following error when deploying: 
```
TypeError: The specifier “src/protojs/nibiru/perp/v2/tx” was a bare specifier, but was not remapped to anything. Relative module specifiers must start with “./”, “../” or “/”.
```

Locally changed all src/protojs to ../../protojs and it was fixed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved path resolution in the build process for better module compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->