### PR TITLE
chore: upgrade graphql

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,8 +45,8 @@
     "@cosmjs/tendermint-rpc": "^0.32.3",
     "bignumber.js": "^9.1.1",
     "cross-fetch": "4.0.0",
-    "graphql": "^16.7.1",
-    "graphql-ws": "^5.14.0",
+    "graphql": "^16.9.0",
+    "graphql-ws": "^5.16.0",
     "pako": "^2.1.0"
   },
   "peerDependencies": {
@@ -54,7 +54,7 @@
     "@cosmjs/proto-signing": "^0.32.3",
     "@cosmjs/stargate": "^0.32.3",
     "@cosmjs/tendermint-rpc": "^0.32.3",
-    "graphql": "^16.7.1"
+    "graphql": "^16.9.0"
   },
   "devDependencies": {
     "@bufbuild/buf": "^1.28.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4802,10 +4802,15 @@ graphql-ws@^5.14.0:
   resolved "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.14.0.tgz"
   integrity sha512-itrUTQZP/TgswR4GSSYuwWUzrE/w5GhbwM2GX3ic2U7aw33jgEsayfIlvaj7/GcIvZgNMzsPTrE5hqPuFUiE5g==
 
-graphql@^16.7.1:
-  version "16.8.0"
-  resolved "https://registry.npmjs.org/graphql/-/graphql-16.8.0.tgz"
-  integrity sha512-0oKGaR+y3qcS5mCu1vb7KG+a89vjn06C7Ihq/dDl3jA+A8B3TKomvi3CiEcVLJQGalbu8F52LxkOym7U5sSfbg==
+graphql-ws@^5.16.0:
+  version "5.16.0"
+  resolved "https://registry.yarnpkg.com/graphql-ws/-/graphql-ws-5.16.0.tgz#849efe02f384b4332109329be01d74c345842729"
+  integrity sha512-Ju2RCU2dQMgSKtArPbEtsK5gNLnsQyTNIo/T7cZNp96niC1x0KdJNZV0TIoilceBPQwfb5itrGl8pkFeOUMl4A==
+
+graphql@^16.9.0:
+  version "16.9.0"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.9.0.tgz#1c310e63f16a49ce1fbb230bd0a000e99f6f115f"
+  integrity sha512-GGTKBX4SD7Wdb8mqeDLni2oaRGYQWjWHGKPQ24ZMnUtKfcsVoiv4uX8+LJr1K6U5VW2Lu1BwJnj7uiori0YtRw==
 
 handlebars@^4.7.7:
   version "4.7.8"


### PR DESCRIPTION
Mitigate GraphQL Vulnerabilities, brought up by ecosystem projects
- https://security.snyk.io/package/npm/graphql/16.7.1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Upgraded dependencies for `graphql` and `graphql-ws`, potentially introducing new features and improvements.
- **Bug Fixes**
	- Updated libraries may include bug fixes that enhance overall application stability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->